### PR TITLE
[Proposal][WIP] Add "make" command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
         "illuminate/view": "^5.6",
         "symfony/console": "~3.0|^4.0",
         "mockery/mockery": "^1.0.0",
-        "mnapoli/front-yaml": "^1.5",
-        "mnapoli/silly": "~1.3"
+        "mnapoli/front-yaml": "^1.5"
     },
     "bin": [
         "jigsaw"

--- a/jigsaw
+++ b/jigsaw
@@ -3,12 +3,14 @@
 
 use TightenCo\Jigsaw\Console\BuildCommand;
 use TightenCo\Jigsaw\Console\InitCommand;
+use TightenCo\Jigsaw\Console\MakeCommand;
 use TightenCo\Jigsaw\Console\ServeCommand;
 
 require_once(__DIR__ . '/jigsaw-core.php');
 
 $app = new Symfony\Component\Console\Application('Jigsaw', '1.0.12');
 $app->add($container[InitCommand::class]);
+$app->add($container[MakeCommand::class]);
 $app->add(new BuildCommand($container));
 $app->add(new ServeCommand($container));
 $app->run();

--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -37,6 +37,8 @@ use TightenCo\Jigsaw\View\BladeMarkdownEngine;
 use TightenCo\Jigsaw\View\MarkdownEngine;
 use TightenCo\Jigsaw\View\ViewRenderer;
 
+die(); // TODO: remove me before merging PR
+
 if (file_exists(__DIR__.'/vendor/autoload.php')) {
     require __DIR__.'/vendor/autoload.php';
 } else {
@@ -122,7 +124,7 @@ $container->bind(MarkdownHandler::class, function ($c) {
     return new MarkdownHandler($c[TemporaryFilesystem::class], $c[FrontMatterParser::class], $c[ViewRenderer::class]);
 });
 
-$container->bind(CollectionPathResolver::class, function ($c ) {
+$container->bind(CollectionPathResolver::class, function ($c) {
     return new CollectionPathResolver($c['outputPathResolver'], $c[ViewRenderer::class]);
 });
 

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -2,15 +2,51 @@
 
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class Command extends SymfonyCommand
 {
+    protected $allowAnyOption = false;
+
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $this->input = $input;
         $this->output = $output;
+
         return (int) $this->fire();
+    }
+
+    public function allowAnyOption()
+    {
+        $this->allowAnyOption = true;
+
+        return $this;
+    }
+
+    public function run(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->allowAnyOption) {
+            $this->addOptionsFromInput($input);
+        }
+
+        parent::run($input, $output);
+    }
+
+    protected function addOptionsFromInput($input)
+    {
+        collect($this->parseOptions($input))->each(function ($option) {
+            if ($option && ! $this->getDefinition()->hasOption($option)) {
+                $this->getDefinition()->addOption(new InputOption($option, null, InputOption::VALUE_REQUIRED));
+            }
+        });
+    }
+
+    protected function parseOptions($input)
+    {
+        preg_match_all('/--(.*?)=/', (String) $input, $options);
+
+        return array_get($options, 1);
     }
 
     protected function info($string)

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -1,0 +1,38 @@
+<?php namespace TightenCo\Jigsaw\Console;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use TightenCo\Jigsaw\File\Filesystem;
+
+class MakeCommand extends Command
+{
+    private $files;
+    private $base;
+
+    public function __construct(Filesystem $files)
+    {
+        $this->files = $files;
+        $this->base = getcwd();
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setName('make')
+            ->setDescription('Scaffold a new file.')
+            ->addArgument('template', InputArgument::OPTIONAL, 'What template should be used for the new file?')
+            ->allowAnyOption();
+    }
+
+    protected function fire()
+    {
+        /**
+         * - Find the template (for 'post' or 'posts', search /posts, /_posts, /post, /_post ?)
+         * - Copy the template, use default filename if none was specified
+         * - Update YAML variables with options from console command
+         * - Update special variables (e.g. dates)
+         * - Respond with location of new file
+         */
+        $this->info('New file was created.');
+    }
+}

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests;
+
+use Symfony\Component\Console\Tester\CommandTester;
+use TightenCo\Jigsaw\Console\MakeCommand;
+
+class MakeCommandTest extends TestCase
+{
+    public function test_jigsaw_make_console_command_can_include_arbitrary_options()
+    {
+        $command = $this->app->make(MakeCommand::class);
+        $command_tester = new CommandTester($command);
+        $command_tester->execute([
+            'template' => 'post',
+            '--abc' => '123',
+            '--def' => '456',
+        ]);
+
+        $this->assertEquals('123', $command_tester->getInput()->getOption('abc'));
+        $this->assertEquals('456', $command_tester->getInput()->getOption('def'));
+    }
+}


### PR DESCRIPTION
This PR is a revision of the feature originally implemented in this PR #164 - thanks, @wilburpowery!!

Below is the feature in its ideal form:

Add a "template" file in a collection's folder: `posts/template.md`

```
---
Title:
Description:
Date: {date|Y-m-d}
---
```

Now run the following command: `jigsaw make:post some_filename --title="Hello World" --description="A really cool blog post"`

A new file will be created called `posts/some_filename.md`

Additionally, if you change the extension of the "template" file, it will be reflected in the generated file. For example: `template.blade.md` will output `some_filename.blade.md`

---

- [X] Allow console commands to accept arbitrary `--` options
- [ ] Consider this format: `jigsaw make post --filename="my-post" --title="Hello World"`
- [ ] Determine default filename
- [ ] Find the template file in singular, plural, underscore, and no-underscore directories?
- [ ] Read YAML options from template and write w/ options from command
- [ ] Process special variables like `date`
- [ ] Tell the user where the new file is located