### PR TITLE
add filter to ignore '.git' in CollectionDataLoader.php

### DIFF
--- a/src/Loaders/CollectionDataLoader.php
+++ b/src/Loaders/CollectionDataLoader.php
@@ -60,7 +60,7 @@ class CollectionDataLoader
 
         return collect($this->filesystem->files($path))
             ->reject(function ($file) {
-                return Str::startsWith($file->getFilename(), '_') || Str::startsWith($file->getFilename(), '.git');
+                return Str::startsWith($file->getFilename(), ['_', '.git']);
             })->tap(function ($files) {
                 $this->consoleOutput->progressBar('collections')->addSteps($files->count());
             })->map(function ($file) {

--- a/src/Loaders/CollectionDataLoader.php
+++ b/src/Loaders/CollectionDataLoader.php
@@ -60,7 +60,7 @@ class CollectionDataLoader
 
         return collect($this->filesystem->files($path))
             ->reject(function ($file) {
-                return Str::startsWith($file->getFilename(), '_');
+                return Str::startsWith($file->getFilename(), '_') || Str::startsWith($file->getFilename(), '.git');
             })->tap(function ($files) {
                 $this->consoleOutput->progressBar('collections')->addSteps($files->count());
             })->map(function ($file) {


### PR DESCRIPTION
See issue [488](https://github.com/tightenco/jigsaw/issues/488).

In `CollectionDataLoader.php`, appended:
Line 63: `return Str::startsWith($file->getFilename(), '_');`
with filter:
Line 63: `return Str::startsWith($file->getFilename(), '_') || Str::startsWith($file->getFilename(), '.git');`
