### PR TITLE
Ignore collection items without a matching handler

### DIFF
--- a/src/Loaders/CollectionDataLoader.php
+++ b/src/Loaders/CollectionDataLoader.php
@@ -61,6 +61,8 @@ class CollectionDataLoader
         return collect($this->filesystem->files($path))
             ->reject(function ($file) {
                 return Str::startsWith($file->getFilename(), '_');
+            })->filter(function ($file) {
+                return $this->hasHandler($file);
             })->tap(function ($files) {
                 $this->consoleOutput->progressBar('collections')->addSteps($files->count());
             })->map(function ($file) {
@@ -96,18 +98,18 @@ class CollectionDataLoader
         return $item;
     }
 
-    private function getHandler($file)
+    private function hasHandler($file): bool
     {
-        $handler = $this->handlers->first(function ($handler) use ($file) {
+        return $this->handlers->contains(function ($handler) use ($file) {
             return $handler->shouldHandle($file);
         });
+    }
 
-        if (! $handler) {
-            throw new Exception('No matching collection item handler for file: '
-                                . $file->getFilenameWithoutExtension() . "." . $file->getExtension() );
-        }
-
-        return $handler;
+    private function getHandler($file)
+    {
+        return $this->handlers->first(function ($handler) use ($file) {
+            return $handler->shouldHandle($file);
+        });
     }
 
     private function getMetaData($file, $collection, $data)

--- a/tests/RemoteCollectionsTest.php
+++ b/tests/RemoteCollectionsTest.php
@@ -50,7 +50,7 @@ class RemoteCollectionsTest extends TestCase
     }
 
     /** @test */
-    public function collection_items_without_matching_handler_throw_exception()
+    public function collection_items_without_matching_handler_are_ignored()
     {
         $config = collect(['collections' => ['collection' => []]]);
         $files = $this->setupSource([
@@ -60,9 +60,10 @@ class RemoteCollectionsTest extends TestCase
             ],
         ]);
 
-        $this->expectExceptionObject(new \Exception('No matching collection item handler for file: .git'));
+        $siteData = $this->buildSiteData($files, $config, 3);
 
-        $siteData = $this->buildSiteData($files, $config);
+        $this->assertTrue($siteData->has('collection'));
+        $this->assertCount(1, $siteData->collection);
     }
 
     /**

--- a/tests/RemoteCollectionsTest.php
+++ b/tests/RemoteCollectionsTest.php
@@ -49,6 +49,22 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
+    /** @test */
+    public function collection_items_without_matching_handler_throw_exception()
+    {
+        $config = collect(['collections' => ['collection' => []]]);
+        $files = $this->setupSource([
+            '_collection' => [
+                '.git' => '-',
+                'file.md' => 'Test markdown file',
+            ],
+        ]);
+
+        $this->expectExceptionObject(new \Exception('No matching collection item handler for file: .git'));
+
+        $siteData = $this->buildSiteData($files, $config);
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
This PR updates Jigsaw to silently ignore collection items without a matching handler, instead of throwing an exception.

Fixes #488, closes #494.
