### PR TITLE
Update default build scripts to not pass --env

### DIFF
--- a/stubs/mix/package.json
+++ b/stubs/mix/package.json
@@ -1,9 +1,9 @@
 {
     "private": true,
     "scripts": {
-        "local": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --env=local --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "staging": "cross-env NODE_ENV=staging node_modules/webpack/bin/webpack.js --progress --hide-modules --env=staging --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --env=production --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "local": "cross-env NODE_ENV=development JIGSAW_ENV=local node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "staging": "cross-env NODE_ENV=staging JIGSAW_ENV=staging node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "production": "cross-env NODE_ENV=production JIGSAW_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
         "dev": "npm run local",
         "prod": "npm run production",
         "watch": "npm run local -- --watch"

--- a/stubs/mix/package.json
+++ b/stubs/mix/package.json
@@ -1,9 +1,9 @@
 {
     "private": true,
     "scripts": {
-        "local": "cross-env NODE_ENV=development JIGSAW_ENV=local node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "staging": "cross-env NODE_ENV=staging JIGSAW_ENV=staging node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "production": "cross-env NODE_ENV=production JIGSAW_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "local": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "staging": "cross-env NODE_ENV=staging node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
         "dev": "npm run local",
         "prod": "npm run production",
         "watch": "npm run local -- --watch"


### PR DESCRIPTION
Fixes #505 (1/2, see tighten/laravel-mix-jigsaw#17). Shouldn't break anything since this is only used for new installs.

~~The reason I went with `JIGSAW_ENV` instead of something like `--environment` or another new argument is so that this is treated as just a regular environment variable. [Laravel Mix v6 is also making this change](https://github.com/JeffreyWay/laravel-mix/commit/c29d2f92456d35b5f92e521f551e089c7f8c94f8), so I think it makes sense to stay consistent with them and aim for forwards-compatibility with other tools.~~

~~We could also just piggyback on `NODE_ENV`, which would mean using `development` instead of `local` here and in `laravel-mix-jigsaw`. Would that be confusing though?~~

We can change `'development'` to `'local'` internally in `laravel-mix-jigsaw`. I don't think it'll be confusing if Jigsaw's 'environment' just isn't an argument that the build script has to pass anymore.