### PR TITLE
Support autoloading class components

### DIFF
--- a/src/View/ComponentTagCompiler.php
+++ b/src/View/ComponentTagCompiler.php
@@ -4,6 +4,7 @@ namespace TightenCo\Jigsaw\View;
 
 use Exception;
 use Illuminate\Container\Container;
+use Illuminate\Support\Str;
 use Illuminate\View\Compilers\ComponentTagCompiler as BaseComponentTagCompiler;
 use Illuminate\View\Factory;
 
@@ -28,8 +29,20 @@ class ComponentTagCompiler extends BaseComponentTagCompiler
             return $view;
         }
 
+        if (class_exists($class = $this->guessClassName($component))) {
+            return $class;
+        }
+
         throw new Exception(
             "Unable to locate a class or view for component [{$component}]."
         );
+    }
+
+    public function guessClassName(string $component)
+    {
+        $componentPieces = array_map(function ($componentPiece) {
+            return ucfirst(Str::camel($componentPiece));
+        }, explode('.', $component));
+        return 'Components\\'.implode('\\', $componentPieces);
     }
 }

--- a/tests/BladeComponentTest.php
+++ b/tests/BladeComponentTest.php
@@ -116,6 +116,55 @@ class BladeComponentTest extends TestCase
             $built
         );
     }
+
+    /**
+     * @test
+     */
+    public function can_include_blade_component_with_x_tag_syntax_using_namespaced_component_with_inline_render()
+    {
+        class_alias('Tests\InlineAlertComponent', 'Components\InlineClassComponent');
+
+        $files = vfsStream::setup('virtual', null, [
+            'source' => [
+                'page.blade.php' => '<h1>Hello</h1><x-inline-class-component type="error" message="The message"/>',
+            ],
+        ]);
+
+        $this->buildSite($files, []);
+
+        $built = $files->getChild('build/page.html')->getContent();
+
+        $this->assertEquals(
+            '<h1>Hello</h1> <div class="alert alert-error">The message</div> ',
+            $built
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function can_include_blade_component_with_x_tag_syntax_using_namespaced_component_with_view()
+    {
+        class_alias('Tests\\AlertComponent', 'Components\\ClassComponent');
+
+        $files = vfsStream::setup('virtual', null, [
+            'source' => [
+                'page.blade.php' => '<h1>Hello</h1><x-class-component type="error" message="The message"/>',
+                '_components' => [
+                    'alert.blade.php' => '<div class="alert alert-{{ $type }}">{{ $message }}</div>',
+                ],
+            ],
+        ]);
+
+        $this->buildSite($files, []);
+
+        $built = $files->getChild('build/page.html')->getContent();
+
+        $this->assertEquals(
+            '<h1>Hello</h1> <div class="alert alert-error">The message</div> ',
+            $built
+        );
+    }
 }
 
 class AlertComponent extends Component


### PR DESCRIPTION
Ahoy-hoy splendid people of Tighten thanks for Jigsaw it's rad-biscuits 💜


I'm rebuilding a static site (originally Gatsby) and have been finding the manual registration of class-based Blade components as discussed in feels #492 a bit of a fiddle / doesn't scale well. For context I'm using inline Blade class components pretty much exclusively (_love_ those inline class components 🙌).

This PR builds on #440 proposes a solution for autoloading based on a `Components` namespace being used. I have intentionally left adding this mapping to `composer.json` as a manual step. After looking at adding this programmatically via `init` I found ensuring correct integration with subclasses of `ScaffoldBuilder` inluding 3rd party presets started throwing up too many questions and my internal KISS 🚨 alarm sounded. A one-off manual opt-in solves the problem at hand and doesn't feel too much like a kludge to me.


Here's the proposed usage:
```
% composer require tightenco/jigsaw
% ./vendor/bin/jigsaw init
```

... add the following to `composer.json`:

```
"autoload": {
  "psr-4": {
    "Components\\": "where/you/want/to/keep/component/classes/"
  }
}
```

...lastly

```
% composer dump-autoload
```

After that any component classes using the `Components` namespace will be automatically discovered when used via the `x-component` syntax in Blade files.

Couple of outstanding questions in my mind which it would be good to hear your thoughts on 🤔

- Should there be a namespace prefix to prevent collisions? (I felt this was overkill for Jigsaw)
- Not super happy about using `class_alias` in the tests due to polluting the test environment but finding a way to usefully mock seemed really convoluted at best. I have mitigated by aliasing to class names which are different to the fixture `Alert` classes in the test file but if you can think of a better approach would be great to hear

Thanks!