### PR TITLE
Use Tailwind CSS and PostCSS instead of SCSS in default installation

### DIFF
--- a/stubs/mix/package.json
+++ b/stubs/mix/package.json
@@ -10,9 +10,9 @@
     },
     "devDependencies": {
         "cross-env": "^3.2.3",
-        "laravel-mix": "^4.0.0",
+        "laravel-mix": "^5.0.5",
         "laravel-mix-jigsaw": "^1.1.0",
-        "sass": "^1.15.2",
-        "sass-loader": "^7.1.0"
+        "postcss-import": "^12.0.0",
+        "tailwindcss": "^1.9.6"
     }
 }

--- a/stubs/mix/tailwind.config.js
+++ b/stubs/mix/tailwind.config.js
@@ -6,7 +6,6 @@ module.exports = {
       'source/**/*.html',
     ]
   },
-  darkMode: false,
   theme: {
     extend: {},
   },

--- a/stubs/mix/tailwind.config.js
+++ b/stubs/mix/tailwind.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  purge: {
+    content: [
+      'source/**/*.blade.php',
+      'source/**/*.md',
+      'source/**/*.html',
+    ]
+  },
+  darkMode: false,
+  theme: {
+    extend: {},
+  },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/stubs/mix/webpack.mix.js
+++ b/stubs/mix/webpack.mix.js
@@ -6,7 +6,10 @@ mix.setPublicPath('source/assets/build');
 
 mix.jigsaw()
     .js('source/_assets/js/main.js', 'js')
-    .sass('source/_assets/sass/main.scss', 'css')
+    .postCss('source/_assets/css/main.css', 'css', [
+        require('postcss-import'),
+        require('tailwindcss'),
+    ])
     .options({
         processCssUrls: false,
     })

--- a/stubs/site/source/_assets/css/main.css
+++ b/stubs/site/source/_assets/css/main.css
@@ -1,0 +1,3 @@
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';

--- a/stubs/site/source/_layouts/master.blade.php
+++ b/stubs/site/source/_layouts/master.blade.php
@@ -10,7 +10,7 @@
         <title>{{ $page->title }}</title>
         <link rel="stylesheet" href="{{ mix('css/main.css', 'assets/build') }}">
     </head>
-    <body>
+    <body class="text-gray-900 font-sans antialiased">
         @yield('body')
     </body>
 </html>

--- a/stubs/site/source/index.blade.php
+++ b/stubs/site/source/index.blade.php
@@ -1,5 +1,7 @@
 @extends('_layouts.master')
 
 @section('body')
-<h1>Hello world!</h1>
+<div class="p-8">
+    <h1 class="text-3xl font-bold">Hello world!</h1>
+</div>
 @endsection


### PR DESCRIPTION
This PR makes the necessary changes to include Tailwind CSS and PostCSS in the default installation instead of SCSS.

- Updated NPM dependencies
- Updated `webpack.mix.js` configuration
- Added `tailwind.config.js` with the `purge` option configured
- Added some very basic styles to the master layout and index page