### PR TITLE
Add badges for build status, Packagist

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
 ![Jigsaw logo](https://raw.githubusercontent.com/tighten/jigsaw/master/jigsaw-banner.png)
 
+[![Run tests](https://github.com/tighten/jigsaw/workflows/CI/badge.svg?branch=master)](https://github.com/tighten/jigsaw/actions?query=workflow%3ACI)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/tightenco/jigsaw.svg?style=flat)](https://packagist.org/packages/tightenco/jigsaw)
+[![Downloads on Packagist](https://img.shields.io/packagist/dt/tightenco/jigsaw.svg?style=flat)](https://packagist.org/packages/tightenco/jigsaw)
+
 Simple static sites with Laravel's [Blade](https://laravel.com/docs/blade).
 
 For documentation, visit https://jigsaw.tighten.co/docs/installation/


### PR DESCRIPTION
Adds badges for github workflow status, Packagist version, and downloads. 

**Rendered in phpstorm markdown preview**
<img width="699" alt="Screen Shot 2020-11-03 at 11 38 19 AM" src="https://user-images.githubusercontent.com/4378273/98020958-4baa0e00-1dc9-11eb-844e-7989df562d28.png">
