### PR TITLE
Allow disabling pretty URLs via config file

### DIFF
--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -41,7 +41,7 @@ class BuildCommand extends Command
         $this->updateBuildPaths($env);
         $cacheExists = $this->app[TemporaryFilesystem::class]->hasTempDirectory();
 
-        if ($this->input->getOption('pretty') === 'true') {
+        if ($this->input->getOption('pretty') === 'true' && $this->app->config->get('pretty') !== false) {
             $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());
         }
 


### PR DESCRIPTION
This PR adds the ability to disable pretty URL generation via the config file. Previously, the only to turn this off was by passing `--pretty=false` to the build command. Now you can also disable it by adding`'pretty' => false` to the top level of `config.php`.

Closes tighten/laravel-mix-jigsaw#18.