### PR TITLE
Add url() helper

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -107,6 +107,15 @@ function mix($path, $manifestDirectory = 'assets')
     return new HtmlString($manifestDirectory . $manifest[$path]);
 }
 
+if (! function_exists('url')) {
+    function url(string $path): string
+    {
+        $c = Container::getInstance();
+
+        return trim($c['config']['baseUrl'], '/') . '/' . trim($path, '/');
+    }
+}
+
 if (! function_exists('dd')) {
     function dd(...$args)
     {

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -4,17 +4,13 @@ namespace Tests;
 
 class HelpersTest extends TestCase
 {
-    /**
-     * @test
-     */
+    /** @test */
     public function public_path_returns_path_to_specified_file_in_default_source_directory()
     {
         $this->assertEquals('source/some-file.md', public_path('some-file.md'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function public_path_returns_path_to_specified_file_in_custom_source_directory()
     {
         $this->app->config = collect([
@@ -26,11 +22,17 @@ class HelpersTest extends TestCase
         $this->assertEquals('src/some-file.md', public_path('some-file.md'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function leftTrimPath_leaves_leading_periods()
     {
         $this->assertEquals('.well-known', leftTrimPath('.well-known'));
+    }
+
+    /** @test */
+    public function url_helper_returns_absolute_url()
+    {
+        $this->app->config = collect(['baseUrl' => 'https://test.com/sub/']);
+
+        $this->assertSame('https://test.com/sub/posts/my-first-post', url('posts/my-first-post'));
     }
 }


### PR DESCRIPTION
Adds a `url()` helper that just prepends the configured `baseUrl` value to whatever you pass it. This makes generating absolute URLs, which are pretty much required for some deployment environments like GitHub Pages, cleaner.

```html
<!-- Before -->

<script src="{{ trim($page->baseUrl, '/') }}{{ mix('js/main.js', 'assets/build') }}" defer></script>

<a href="{{ trim($page->baseUrl, '/') }}/about-me">About Me</a>


<!-- After -->

<script src="{{ url(mix('js/main.js', 'assets/build')) }}" defer></script>

<a href="{{ url('about-me') }}">About Me</a>
```

See #515, https://github.com/tighten/jigsaw/issues/254#issuecomment-415583895, and https://github.com/tighten/jigsaw/issues/442#issuecomment-612903405.