### PR TITLE
Use string key as remote collection item temporary filename, if present

### DIFF
--- a/src/Collection/CollectionRemoteItem.php
+++ b/src/Collection/CollectionRemoteItem.php
@@ -9,13 +9,13 @@ class CollectionRemoteItem
 {
     private $item;
     private $index;
-    private $prefix;
+    private $collectionName;
 
     public function __construct($item, $index = 0, $collectionName = null)
     {
         $this->item = $item;
         $this->index = $index;
-        $this->prefix = $collectionName . '_';
+        $this->collectionName = $collectionName;
     }
 
     public function getContent()
@@ -27,7 +27,11 @@ class CollectionRemoteItem
 
     public function getFilename()
     {
-        return Arr::get($this->item, 'filename', $this->prefix . ($this->index + 1)) . '.blade.md';
+        $default = is_int($this->index)
+            ? $this->collectionName . '-' . ($this->index + 1)
+            : $this->index;
+
+        return Arr::get($this->item, 'filename', $default) . '.blade.md';
     }
 
     protected function getHeader()

--- a/tests/RemoteCollectionsTest.php
+++ b/tests/RemoteCollectionsTest.php
@@ -442,6 +442,37 @@ class RemoteCollectionsTest extends TestCase
     /**
      * @test
      */
+    public function filename_for_output_file_is_set_to_collection_name_plus_array_key_if_filename_not_specified_and_key_is_string()
+    {
+        $config = collect([
+            'collections' => [
+                'test' => [
+                    'extends' => '_layouts.master',
+                    'items' => [
+                        'foo' => [
+                            'content' => 'item 1',
+                        ],
+                        'bar' => [
+                            'content' => 'item 2',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $files = $this->setupSource([
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
+            ],
+        ]);
+        $this->buildSite($files, $config);
+
+        $this->assertTrue($files->hasChild('build/test/foo.html'));
+        $this->assertTrue($files->hasChild('build/test/bar.html'));
+    }
+
+    /**
+     * @test
+     */
     public function filename_for_output_file_is_set_to_filename_key_if_specified()
     {
         $config = collect([


### PR DESCRIPTION
This PR updates handling of the temporary filename for a remote collection item, which was failing on PHP 8 when encountering a string key. If present, the string key will be used as the filename, rather than concatenating a numeric index to the collection name.

Addresses https://github.com/tighten/jigsaw/issues/524