### PR TITLE
update devDependencies in package.json for TailwindCSS v2 compat build

### DIFF
--- a/stubs/mix/package.json
+++ b/stubs/mix/package.json
@@ -9,10 +9,13 @@
         "watch": "npm run local -- --watch"
     },
     "devDependencies": {
+        "@tailwindcss/postcss7-compat": "^2.0.2",
+        "autoprefixer": "^9.8.6",
         "cross-env": "^3.2.3",
         "laravel-mix": "^5.0.5",
         "laravel-mix-jigsaw": "^1.1.0",
+        "postcss": "^7.0.35",
         "postcss-import": "^12.0.0",
-        "tailwindcss": "^1.9.6"
+        "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.2"
     }
 }


### PR DESCRIPTION
This PR updates the devDependencies in package.json for the TailwindCSS v2 compat build.  

Details for compatibility build: https://tailwindcss.com/docs/installation#post-css-7-compatibility-build