### PR TITLE
Bind page data into container

### DIFF
--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -2,9 +2,10 @@
 
 namespace TightenCo\Jigsaw;
 
-use TightenCo\Jigsaw\File\InputFile;
-use TightenCo\Jigsaw\File\Filesystem;
+use Illuminate\Container\Container;
 use TightenCo\Jigsaw\Console\ConsoleOutput;
+use TightenCo\Jigsaw\File\Filesystem;
+use TightenCo\Jigsaw\File\InputFile;
 
 class SiteBuilder
 {
@@ -117,7 +118,10 @@ class SiteBuilder
     {
         $meta = $this->getMetaData($file, $siteData->page->baseUrl);
 
-        return $this->getHandler($file)->handle($file, PageData::withPageMetaData($siteData, $meta));
+        $pageData = PageData::withPageMetaData($siteData, $meta);
+        Container::getInstance()->instance('pagedata', $pageData);
+
+        return $this->getHandler($file)->handle($file, $pageData);
     }
 
     private function getHandler($file)

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -119,7 +119,7 @@ class SiteBuilder
         $meta = $this->getMetaData($file, $siteData->page->baseUrl);
 
         $pageData = PageData::withPageMetaData($siteData, $meta);
-        Container::getInstance()->instance('pagedata', $pageData);
+        Container::getInstance()->instance('pageData', $pageData);
 
         return $this->getHandler($file)->handle($file, $pageData);
     }

--- a/tests/PageDataBindingTest.php
+++ b/tests/PageDataBindingTest.php
@@ -44,7 +44,7 @@ class TestPageHeaderComponent extends Component
 
     public function __construct()
     {
-        $this->page = Container::getInstance()->make('pagedata');
+        $this->page = Container::getInstance()->make('pageData');
     }
 
     public function render()

--- a/tests/PageDataBindingTest.php
+++ b/tests/PageDataBindingTest.php
@@ -31,7 +31,7 @@ class PageDataBindingTest extends TestCase
 
         $data = json_decode(Str::between($built, '<div>Header: ', '</div>'), true);
 
-        $this->assertTrue(Str::endsWith($data['page']['view.compiled'], '/jigsaw/jigsaw/cache'));
+        $this->assertTrue(Str::endsWith($data['page']['view.compiled'], '/jigsaw/cache'));
         $this->assertSame('page', $data['page']['_meta']['filename']);
         $this->assertSame('/page.html', $data['page']['_meta']['path']);
         $this->assertSame('/page.html', $data['page']['_meta']['url']);

--- a/tests/PageDataBindingTest.php
+++ b/tests/PageDataBindingTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Container\Container;
+use Illuminate\View\Component;
+use Illuminate\Support\Str;
+use org\bovigo\vfs\vfsStream;
+use TightenCo\Jigsaw\PageData;
+
+class PageDataBindingTest extends TestCase
+{
+    /** @test */
+    public function can_bind_data_for_current_page_into_container()
+    {
+        class_alias('Tests\TestPageHeaderComponent', 'Components\PageHeader');
+
+        $this->app->resolving('Tests\TestPageHeaderComponent', function ($component) {
+            $this->assertTrue($component->page instanceof PageData);
+        });
+
+        $files = vfsStream::setup('virtual', null, [
+            'source' => [
+                'page.blade.php' => '<x-page-header/>',
+            ],
+        ]);
+
+        $this->buildSite($files, []);
+
+        $built = $files->getChild('build/page.html')->getContent();
+
+        $data = json_decode(Str::between($built, '<div>Header: ', '</div>'), true);
+
+        $this->assertTrue(Str::endsWith($data['page']['view.compiled'], '/jigsaw/jigsaw/cache'));
+        $this->assertSame('page', $data['page']['_meta']['filename']);
+        $this->assertSame('/page.html', $data['page']['_meta']['path']);
+        $this->assertSame('/page.html', $data['page']['_meta']['url']);
+    }
+}
+
+class TestPageHeaderComponent extends Component
+{
+    public $page;
+
+    public function __construct()
+    {
+        $this->page = Container::getInstance()->make('pagedata');
+    }
+
+    public function render()
+    {
+        return '<div>Header: {!! json_encode($page) !!}</div>';
+    }
+}


### PR DESCRIPTION
This PR binds Jigsaw's page data into the container as `'pageData'` immediately before rendering each Blade template, making it possible to inject into components as described in https://github.com/tighten/jigsaw/issues/492#issuecomment-762669802:

```php
<?php

namespace Components;

use Illuminate\View\Component;
use Illuminate\Container\Container;

class Layout extends Component
{
    public $page;

    public function __construct()
    {
        $this->page = Container::getInstance()->make('pageData');
    }

    public function render()
    {        
        return Container::getInstance()->make('view')->make('_components.layout');
    }
}
```

```blade
{{-- source/index.blade.php --}}

{{-- No longer necessary to pass $page in manually! --}}
<x-layout>
    <div class="p-8">
        <h1 class="text-3xl font-bold">Hello world!</h1>
    </div>
</x-layout>
```