### PR TITLE
Allow Collection Specific perPage Setting

### DIFF
--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -41,16 +41,17 @@ class PaginatedPageHandler
 
     public function handle($file, PageData $pageData)
     {
-        $pageData->page->addVariables($this->getPageVariables($file));
+        $page = $pageData->page;
+        $page->addVariables($this->getPageVariables($file));
+        $collection = $page->pagination->collection;
 
         return $this->paginator->paginate(
             $file,
-            $pageData->get($pageData->page->pagination->collection),
-            $pageData->page->pagination->perPage ?: (
-                $pageData->page->collections->{$pageData->page->pagination->collection}->perPage ?: (
-                    $pageData->page->perPage ?: 10
-                )
-            )
+            $pageData->get($collection),
+            $page->pagination->perPage
+                ?: $page->collections->{$collection}->perPage
+                ?: $page->perPage
+                ?: 10
         )->map(function ($page) use ($file, $pageData) {
             $pageData->setPagePath($page->current);
             $pageData->put('pagination', $page);

--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -46,7 +46,11 @@ class PaginatedPageHandler
         return $this->paginator->paginate(
             $file,
             $pageData->get($pageData->page->pagination->collection),
-            $pageData->page->pagination->perPage ?: ($pageData->page->perPage ?: 10)
+            $pageData->page->pagination->perPage ?: (
+                $pageData->page->collections->{$pageData->page->pagination->collection}->perPage ?: (
+                    $pageData->page->perPage ?: 10
+                )
+            )
         )->map(function ($page) use ($file, $pageData) {
             $pageData->setPagePath($page->current);
             $pageData->put('pagination', $page);

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -93,4 +93,271 @@ class PaginationTest extends TestCase
             $this->clean($files->getChild('build/blog/3/index.html')->getContent())
         );
     }
+
+    /**
+     * @test
+     */
+    public function blade_template_file_pagination_perPage_setting_defaults_to_config_global_setting()
+    {
+        $config = collect(['perPage' => 2, 'collections' => ['posts' => []]]);
+
+        $yaml_header = implode("\n", [
+            '---',
+            'pagination:',
+            '    collection: posts',
+            '---',
+        ]);
+
+        $files = $this->setupSource([
+            '_layouts' => [
+                'post.blade.php' => '@section(\'content\') @endsection',
+            ],
+            '_posts' => [
+                'post1.blade.php' => "@extends('_layouts.post')\n" . '1',
+                'post2.blade.php' => "@extends('_layouts.post')\n" . '2',
+                'post3.blade.php' => "@extends('_layouts.post')\n" . '3',
+                'post4.blade.php' => "@extends('_layouts.post')\n" . '4',
+                'post5.blade.php' => "@extends('_layouts.post')\n" . '5',
+            ],
+            'blog.blade.php' => $yaml_header . '@foreach($pagination->items as $item) {{ $item->getFilename() }}@endforeach',
+        ]);
+
+        $this->buildSite($files, $config, $pretty = true);
+
+        $this->assertEquals(
+            'post1 post2',
+            $this->clean($files->getChild('build/blog/index.html')->getContent())
+        );
+        $this->assertEquals(
+            'post3 post4',
+            $this->clean($files->getChild('build/blog/2/index.html')->getContent())
+        );
+        $this->assertEquals(
+            'post5',
+            $this->clean($files->getChild('build/blog/3/index.html')->getContent())
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function blade_template_file_pagination_perPage_setting_defaults_to_config_collection_setting()
+    {
+        $config = collect(['collections' => ['posts' => ['perPage' => 2]]]);
+
+        $yaml_header = implode("\n", [
+            '---',
+            'pagination:',
+            '    collection: posts',
+            '---',
+        ]);
+
+        $files = $this->setupSource([
+            '_layouts' => [
+                'post.blade.php' => '@section(\'content\') @endsection',
+            ],
+            '_posts' => [
+                'post1.blade.php' => "@extends('_layouts.post')\n" . '1',
+                'post2.blade.php' => "@extends('_layouts.post')\n" . '2',
+                'post3.blade.php' => "@extends('_layouts.post')\n" . '3',
+                'post4.blade.php' => "@extends('_layouts.post')\n" . '4',
+                'post5.blade.php' => "@extends('_layouts.post')\n" . '5',
+            ],
+            'blog.blade.php' => $yaml_header . '@foreach($pagination->items as $item) {{ $item->getFilename() }}@endforeach',
+        ]);
+
+        $this->buildSite($files, $config, $pretty = true);
+
+        $this->assertEquals(
+            'post1 post2',
+            $this->clean($files->getChild('build/blog/index.html')->getContent())
+        );
+        $this->assertEquals(
+            'post3 post4',
+            $this->clean($files->getChild('build/blog/2/index.html')->getContent())
+        );
+        $this->assertEquals(
+            'post5',
+            $this->clean($files->getChild('build/blog/3/index.html')->getContent())
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function blade_template_file_pagination_perPage_setting_defaults_to_config_collection_setting_when_config_global_setting_exists()
+    {
+        $config = collect(['perPage' => 10, 'collections' => ['posts' => ['perPage' => 2]]]);
+
+        $yaml_header = implode("\n", [
+            '---',
+            'pagination:',
+            '    collection: posts',
+            '---',
+        ]);
+
+        $files = $this->setupSource([
+            '_layouts' => [
+                'post.blade.php' => '@section(\'content\') @endsection',
+            ],
+            '_posts' => [
+                'post1.blade.php' => "@extends('_layouts.post')\n" . '1',
+                'post2.blade.php' => "@extends('_layouts.post')\n" . '2',
+                'post3.blade.php' => "@extends('_layouts.post')\n" . '3',
+                'post4.blade.php' => "@extends('_layouts.post')\n" . '4',
+                'post5.blade.php' => "@extends('_layouts.post')\n" . '5',
+            ],
+            'blog.blade.php' => $yaml_header . '@foreach($pagination->items as $item) {{ $item->getFilename() }}@endforeach',
+        ]);
+
+        $this->buildSite($files, $config, $pretty = true);
+
+        $this->assertEquals(
+            'post1 post2',
+            $this->clean($files->getChild('build/blog/index.html')->getContent())
+        );
+        $this->assertEquals(
+            'post3 post4',
+            $this->clean($files->getChild('build/blog/2/index.html')->getContent())
+        );
+        $this->assertEquals(
+            'post5',
+            $this->clean($files->getChild('build/blog/3/index.html')->getContent())
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function blade_template_file_pagination_perPage_setting_overrides_config_global_setting()
+    {
+        $config = collect(['perPage' => 10, 'collections' => ['posts' => []]]);
+
+        $yaml_header = implode("\n", [
+            '---',
+            'pagination:',
+            '    collection: posts',
+            '    perPage: 2',
+            '---',
+        ]);
+
+        $files = $this->setupSource([
+            '_layouts' => [
+                'post.blade.php' => '@section(\'content\') @endsection',
+            ],
+            '_posts' => [
+                'post1.blade.php' => "@extends('_layouts.post')\n" . '1',
+                'post2.blade.php' => "@extends('_layouts.post')\n" . '2',
+                'post3.blade.php' => "@extends('_layouts.post')\n" . '3',
+                'post4.blade.php' => "@extends('_layouts.post')\n" . '4',
+                'post5.blade.php' => "@extends('_layouts.post')\n" . '5',
+            ],
+            'blog.blade.php' => $yaml_header . '@foreach($pagination->items as $item) {{ $item->getFilename() }}@endforeach',
+        ]);
+
+        $this->buildSite($files, $config, $pretty = true);
+
+        $this->assertEquals(
+            'post1 post2',
+            $this->clean($files->getChild('build/blog/index.html')->getContent())
+        );
+        $this->assertEquals(
+            'post3 post4',
+            $this->clean($files->getChild('build/blog/2/index.html')->getContent())
+        );
+        $this->assertEquals(
+            'post5',
+            $this->clean($files->getChild('build/blog/3/index.html')->getContent())
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function blade_template_file_pagination_perPage_setting_overrides_config_collection_setting()
+    {
+        $config = collect(['collections' => ['posts' => ['perPage' => 10]]]);
+
+        $yaml_header = implode("\n", [
+            '---',
+            'pagination:',
+            '    collection: posts',
+            '    perPage: 2',
+            '---',
+        ]);
+
+        $files = $this->setupSource([
+            '_layouts' => [
+                'post.blade.php' => '@section(\'content\') @endsection',
+            ],
+            '_posts' => [
+                'post1.blade.php' => "@extends('_layouts.post')\n" . '1',
+                'post2.blade.php' => "@extends('_layouts.post')\n" . '2',
+                'post3.blade.php' => "@extends('_layouts.post')\n" . '3',
+                'post4.blade.php' => "@extends('_layouts.post')\n" . '4',
+                'post5.blade.php' => "@extends('_layouts.post')\n" . '5',
+            ],
+            'blog.blade.php' => $yaml_header . '@foreach($pagination->items as $item) {{ $item->getFilename() }}@endforeach',
+        ]);
+
+        $this->buildSite($files, $config, $pretty = true);
+
+        $this->assertEquals(
+            'post1 post2',
+            $this->clean($files->getChild('build/blog/index.html')->getContent())
+        );
+        $this->assertEquals(
+            'post3 post4',
+            $this->clean($files->getChild('build/blog/2/index.html')->getContent())
+        );
+        $this->assertEquals(
+            'post5',
+            $this->clean($files->getChild('build/blog/3/index.html')->getContent())
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function blade_template_file_pagination_perPage_setting_overrides_config_collection_and_global_settings()
+    {
+        $config = collect(['perPage' => 20, 'collections' => ['posts' => ['perPage' => 10]]]);
+
+        $yaml_header = implode("\n", [
+            '---',
+            'pagination:',
+            '    collection: posts',
+            '    perPage: 2',
+            '---',
+        ]);
+
+        $files = $this->setupSource([
+            '_layouts' => [
+                'post.blade.php' => '@section(\'content\') @endsection',
+            ],
+            '_posts' => [
+                'post1.blade.php' => "@extends('_layouts.post')\n" . '1',
+                'post2.blade.php' => "@extends('_layouts.post')\n" . '2',
+                'post3.blade.php' => "@extends('_layouts.post')\n" . '3',
+                'post4.blade.php' => "@extends('_layouts.post')\n" . '4',
+                'post5.blade.php' => "@extends('_layouts.post')\n" . '5',
+            ],
+            'blog.blade.php' => $yaml_header . '@foreach($pagination->items as $item) {{ $item->getFilename() }}@endforeach',
+        ]);
+
+        $this->buildSite($files, $config, $pretty = true);
+
+        $this->assertEquals(
+            'post1 post2',
+            $this->clean($files->getChild('build/blog/index.html')->getContent())
+        );
+        $this->assertEquals(
+            'post3 post4',
+            $this->clean($files->getChild('build/blog/2/index.html')->getContent())
+        );
+        $this->assertEquals(
+            'post5',
+            $this->clean($files->getChild('build/blog/3/index.html')->getContent())
+        );
+    }
 }


### PR DESCRIPTION
Currently, you can set the `perPage` setting either in your template file or as a global setting in config.php. This pull request would allow you to set the `perPage` setting for a specific collection in config.php. The order of preference would be as follows:

1. Within template
2. Collection specific in config.php
3. Global in config.php
4. Default of 10

Note that I don't really love how this looks in the code itself, but it's better than keeping it all on the same line together. One alternative would be a temporary variable, which I don't love either. I'm open to other implementation suggestions.