### PR TITLE
Allow the use of versions and constraints when using jigsaw init command

### DIFF
--- a/src/Scaffold/PresetPackage.php
+++ b/src/Scaffold/PresetPackage.php
@@ -15,6 +15,7 @@ class PresetPackage
         'docs' => 'tightenco/jigsaw-docs-template',
     ];
 
+    public $constraint;
     public $name;
     public $nameShort;
     public $path;
@@ -79,8 +80,10 @@ class PresetPackage
         }
 
         $parts = explode('/', $name, 3);
+        $composerName = explode(':',Arr::get($parts, 1));
         $this->vendor = Arr::get($parts, 0);
-        $this->name = Arr::get($parts, 1);
+        $this->name = $composerName[0];
+        $this->constraint = $composerName[1] ?? '';
         $this->suffix = Arr::get($parts, 2);
         $this->shortName = $this->getShortName();
     }
@@ -100,6 +103,9 @@ class PresetPackage
 
         if (! $this->files->exists($this->path)) {
             $package = $this->vendor . '/' . $this->name;
+            if (!empty($this->constraint)) {
+                $package .= ':' . $this->constraint;
+            }
 
             try {
                 $this->installPackageFromComposer($package);


### PR DESCRIPTION
Allow the use of versions and constraints when using jigsaw init command

If one would like to use theme-vendor/my-theme:dev-main
e.g. during theme development
it will end with a failure
In Finder.php line 591:
The "/path/to/jigsaw_site/vendor/theme-vendor/my-theme:dev-main" directory does not exist.

The path comes from PresetPackage->name

Solution:
split up PresetPackage->name in PresetPackage->name and PresetPackage->constraint and concatenate them where needed.

Because the PresetPackage expected the name to be without a constraint (:xy) until now, this should not be breaking anything.
