### PR TITLE
Give precedence to class based component

### DIFF
--- a/src/View/ComponentTagCompiler.php
+++ b/src/View/ComponentTagCompiler.php
@@ -24,13 +24,13 @@ class ComponentTagCompiler extends BaseComponentTagCompiler
             return $this->aliases[$component];
         }
 
+        if (class_exists($class = $this->guessClassName($component))) {
+            return $class;
+        }
+
         if (Container::getInstance()[Factory::class]
             ->exists($view = "_components.{$component}")) {
             return $view;
-        }
-
-        if (class_exists($class = $this->guessClassName($component))) {
-            return $class;
         }
 
         throw new Exception(

--- a/src/View/ComponentTagCompiler.php
+++ b/src/View/ComponentTagCompiler.php
@@ -2,11 +2,12 @@
 
 namespace TightenCo\Jigsaw\View;
 
-use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Support\Str;
 use Illuminate\View\Compilers\ComponentTagCompiler as BaseComponentTagCompiler;
 use Illuminate\View\Factory;
+use Illuminate\View\ViewFinderInterface;
+use InvalidArgumentException;
 
 class ComponentTagCompiler extends BaseComponentTagCompiler
 {
@@ -20,29 +21,65 @@ class ComponentTagCompiler extends BaseComponentTagCompiler
      */
     protected function componentClass(string $component)
     {
+        $viewFactory = Container::getInstance()[Factory::class];
+
         if (isset($this->aliases[$component])) {
-            return $this->aliases[$component];
+            if (class_exists($alias = $this->aliases[$component])) {
+                return $alias;
+            }
+
+            if ($viewFactory->exists($alias)) {
+                return $alias;
+            }
+
+            throw new InvalidArgumentException(
+                "Unable to locate class or view [{$alias}] for component [{$component}]."
+            );
         }
 
         if (class_exists($class = $this->guessClassName($component))) {
             return $class;
         }
 
-        if (Container::getInstance()[Factory::class]
-            ->exists($view = "_components.{$component}")) {
+        if ($viewFactory->exists($view = $this->guessViewName($component))) {
             return $view;
         }
 
-        throw new Exception(
+        throw new InvalidArgumentException(
             "Unable to locate a class or view for component [{$component}]."
         );
     }
 
+    /**
+     * Guess the class name for the given component.
+     *
+     * @param  string  $component
+     * @return string
+     */
     public function guessClassName(string $component)
     {
         $componentPieces = array_map(function ($componentPiece) {
             return ucfirst(Str::camel($componentPiece));
         }, explode('.', $component));
         return 'Components\\'.implode('\\', $componentPieces);
+    }
+
+    /**
+     * Guess the view name for the given component.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    public function guessViewName($name)
+    {
+        $prefix = '_components.';
+
+        $delimiter = ViewFinderInterface::HINT_PATH_DELIMITER;
+
+        if (Str::contains($name, $delimiter)) {
+            return Str::replaceFirst($delimiter, $delimiter.$prefix, $name);
+        }
+
+        return $prefix.$name;
     }
 }


### PR DESCRIPTION
Thanks Tighten team for this static site generator.

Following the latest additions for Blade components support I want to propose a change in the anonymous vs class based component precedence giving precedence to class based ones. 

Assuming a Blade template for the component is defined in `_components`, e.g. `_components/image.blade.php`, and the corresponding Component class defined, e.g. `Image extends Component` under the `Components` namespace, inverting the evaluation criteria for class based components with anonymous components allows to add methods and additional attributes to the component that otherwise would be ignored.

This probably covers my specific case in which I need to define an image component whose Blade file is located under `_components/image.blade.php` and whose logic, for processing the image file, is defined in the `Image` component class in the `Components` namespace. This is required for my experiment in adding support for cache busting and responsive images to the blog I'm working on. 