### PR TITLE
Check build destination existence before prompting to overwrite

### DIFF
--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -108,7 +108,7 @@ class BuildCommand extends Command
         if (! $this->input->getOption('quiet')) {
             $customPath = Arr::get($this->app->config, 'build.destination');
 
-            if ($customPath && strpos($customPath, 'build_') !== 0) {
+            if ($customPath && strpos($customPath, 'build_') !== 0 && file_exists($customPath)) {
                 return $this->console->confirm('Overwrite "' . $this->app->buildPath['destination'] . '"? ');
             }
         }


### PR DESCRIPTION
Currently, if you're using a custom build destination like `/public`, Jigsaw prompts to "Overwrite /home/my-site/public?" on every build, even if that directory doesn't exist. This PR checks for it and only waits for confirmation to overwrite it if it actually already exists.