### PR TITLE
Allow configuration of Blade view path

### DIFF
--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -67,6 +67,7 @@ $bootstrapFile = $container['cwd'] . '/bootstrap.php';
 
 $container->instance('buildPath', [
     'source' => $container['cwd'] . '/source',
+    'views' => $container['cwd'] . '/source',
     'destination' => $container['cwd'] . '/build_{env}',
 ]);
 
@@ -122,7 +123,7 @@ $container->singleton(Factory::class, function ($c) use ($cachePath, $bladeCompi
     });
 
     $resolver->register('markdown', function () use ($c) {
-        return new MarkdownEngine($c[FrontMatterParser::class], new Filesystem, $c['buildPath']['source']);
+        return new MarkdownEngine($c[FrontMatterParser::class], new Filesystem, $c['buildPath']['views']);
     });
 
     $resolver->register('blade-markdown', function () use ($c, $compilerEngine) {
@@ -131,7 +132,7 @@ $container->singleton(Factory::class, function ($c) use ($cachePath, $bladeCompi
 
     (new BladeDirectivesFile($c['cwd'] . '/blade.php', $bladeCompiler))->register();
 
-    $finder = new FileViewFinder(new Filesystem, [$cachePath, $c['buildPath']['source']]);
+    $finder = new FileViewFinder(new Filesystem, [$cachePath, $c['buildPath']['views']]);
 
     $factory = new Factory($resolver, $finder, new FakeDispatcher());
     $factory->setContainer($c);

--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -67,7 +67,6 @@ $bootstrapFile = $container['cwd'] . '/bootstrap.php';
 
 $container->instance('buildPath', [
     'source' => $container['cwd'] . '/source',
-    'views' => $container['cwd'] . '/source',
     'destination' => $container['cwd'] . '/build_{env}',
 ]);
 

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -86,7 +86,7 @@ class BuildCommand extends Command
     {
         $this->app->buildPath = [
             'source' => $this->getBuildPath('source', $env),
-            'views' => $this->getBuildPath('views', $env),
+            'views' => $this->getBuildPath('views', $env) ?: $this->getBuildPath('source', $env),
             'destination' => $this->getBuildPath('destination', $env),
         ];
     }
@@ -94,7 +94,9 @@ class BuildCommand extends Command
     private function getBuildPath($pathType, $env)
     {
         $customPath = Arr::get($this->app->config, 'build.' . $pathType);
-        $buildPath = $customPath ? $this->getAbsolutePath($customPath) : $this->app->buildPath[$pathType];
+        $buildPath = $customPath
+            ? $this->getAbsolutePath($customPath)
+            :  Arr::get($this->app->buildPath, $pathType);
 
         return str_replace('{env}', $env, $buildPath);
     }

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -86,6 +86,7 @@ class BuildCommand extends Command
     {
         $this->app->buildPath = [
             'source' => $this->getBuildPath('source', $env),
+            'views' => $this->getBuildPath('views', $env),
             'destination' => $this->getBuildPath('destination', $env),
         ];
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,6 +27,7 @@ class TestCase extends BaseTestCase
         $this->app = $container;
         $this->app->buildPath = [
             'source' => $this->sourcePath,
+            'views' => $this->sourcePath,
             'destination' => $this->destinationPath,
         ];
         $this->filesystem = new Filesystem();
@@ -81,6 +82,7 @@ class TestCase extends BaseTestCase
         $this->app->config = collect($this->app->config)->merge($config);
         $this->app->buildPath = [
             'source' => $vfs->url() . '/source',
+            'views' => $vfs->url() . '/source',
             'destination' => $vfs->url() . '/build',
         ];
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -76,13 +76,13 @@ class TestCase extends BaseTestCase
         return $siteData->addCollectionData($collectionData);
     }
 
-    public function buildSite($vfs, $config = [], $pretty = false)
+    public function buildSite($vfs, $config = [], $pretty = false, $viewPath = '/source')
     {
         $this->app->consoleOutput->setup($verbosity = -1);
         $this->app->config = collect($this->app->config)->merge($config);
         $this->app->buildPath = [
             'source' => $vfs->url() . '/source',
-            'views' => $vfs->url() . '/source',
+            'views' => $vfs->url() . $viewPath,
             'destination' => $vfs->url() . '/build',
         ];
 

--- a/tests/ViewPathTest.php
+++ b/tests/ViewPathTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests;
+
+use org\bovigo\vfs\vfsStream;
+
+class ViewPathTest extends TestCase
+{
+    /** @test */
+    public function can_load_views_from_custom_path()
+    {
+        $files = vfsStream::setup('virtual', null, [
+            'source' => [
+                'page.md' => <<<MD
+                ---
+                extends: main
+                ---
+                # Hello world!
+                MD,
+            ],
+            'views' => [
+                'main.blade.php' => <<<BLADE
+                <body>
+                    @yield('content')
+                </body>
+                BLADE,
+            ],
+        ]);
+
+        $this->buildSite($files, [], false, '/views');
+
+        $this->assertSame(<<<HTML
+            <body>
+                <h1>Hello world!</h1>
+            </body>
+            HTML,
+            $files->getChild('build/page.html')->getContent()
+        );
+    }
+}


### PR DESCRIPTION
This PR allows users to configure the location of the Blade view path. This facilitates, for example, storing Blade views somewhere other than `source/`. Defaults to `source/` so should be entirely backwards compatible.