### PR TITLE
Add ability to prefix pagination paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
-.DS_Store
-/_tmp/
-/cache/
-/build_local/
-/node_modules/
-/vendor/
+cache/
+vendor/
 .phpunit.result.cache
 .php_cs.cache
-.idea
+composer.lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/src/Collection/CollectionPaginator.php
+++ b/src/Collection/CollectionPaginator.php
@@ -7,16 +7,18 @@ use TightenCo\Jigsaw\IterableObject;
 class CollectionPaginator
 {
     private $outputPathResolver;
+    private $prefix;
 
     public function __construct($outputPathResolver)
     {
         $this->outputPathResolver = $outputPathResolver;
     }
 
-    public function paginate($file, $items, $perPage)
+    public function paginate($file, $items, $perPage, $prefix)
     {
         $chunked = collect($items)->chunk($perPage);
         $totalPages = $chunked->count();
+        $this->prefix = $prefix;
         $numberedPageLinks = $chunked->map(function ($_, $i) use ($file) {
             $page = $i + 1;
 
@@ -46,7 +48,8 @@ class CollectionPaginator
             $file->getRelativePath(),
             $file->getFilenameWithoutExtension(),
             'html',
-            $pageNumber
+            $pageNumber,
+            $this->prefix
         );
 
         return $link !== '/' ? rightTrimPath($link) : $link;

--- a/src/File/OutputFile.php
+++ b/src/File/OutputFile.php
@@ -14,8 +14,9 @@ class OutputFile
     private $contents;
     private $data;
     private $page;
+    private $prefix;
 
-    public function __construct(InputFile $inputFile, $path, $name, $extension, $contents, $data, $page = 1)
+    public function __construct(InputFile $inputFile, $path, $name, $extension, $contents, $data, $page = 1, $prefix = '')
     {
         $this->setInputFile($inputFile, $data);
         $this->path = $path;
@@ -24,6 +25,7 @@ class OutputFile
         $this->contents = $contents;
         $this->data = $data;
         $this->page = $page;
+        $this->prefix = $prefix;
     }
 
     public function setInputFile(InputFile $inputFile, PageData $data)
@@ -65,6 +67,11 @@ class OutputFile
     public function page()
     {
         return $this->page;
+    }
+
+    public function prefix()
+    {
+        return $this->prefix;
     }
 
     public function putContents($destination)

--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -44,6 +44,10 @@ class PaginatedPageHandler
         $page = $pageData->page;
         $page->addVariables($this->getPageVariables($file));
         $collection = $page->pagination->collection;
+        $prefix = $page->pagination->prefix
+            ?: $page->collections->{$collection}->prefix
+            ?: $page->prefix
+            ?: '';
 
         return $this->paginator->paginate(
             $file,
@@ -51,8 +55,9 @@ class PaginatedPageHandler
             $page->pagination->perPage
                 ?: $page->collections->{$collection}->perPage
                 ?: $page->perPage
-                ?: 10
-        )->map(function ($page) use ($file, $pageData) {
+                ?: 10,
+            $prefix,
+        )->map(function ($page) use ($file, $pageData, $prefix) {
             $pageData->setPagePath($page->current);
             $pageData->put('pagination', $page);
             $extension = strtolower($file->getExtension());
@@ -64,7 +69,8 @@ class PaginatedPageHandler
                 ($extension == 'php' || $extension == 'md') ? 'html' : $extension,
                 $this->render($file, $pageData),
                 $pageData,
-                $page->currentPage
+                $page->currentPage,
+                $prefix
             );
         });
     }

--- a/src/PathResolvers/PrettyOutputPathResolver.php
+++ b/src/PathResolvers/PrettyOutputPathResolver.php
@@ -4,11 +4,11 @@ namespace TightenCo\Jigsaw\PathResolvers;
 
 class PrettyOutputPathResolver
 {
-    public function link($path, $name, $type, $page = 1)
+    public function link($path, $name, $type, $page = 1, $prefix = '')
     {
         if ($type === 'html' && $name === 'index') {
             if ($page > 1) {
-                return '/' . leftTrimPath(trimPath($path) . '/') . $page . '/';
+                return '/' . leftTrimPath(trimPath($path) . '/') . trimPath($prefix . '/' . $page) . '/';
             }
 
             return  leftTrimPath('/' . trimPath($path) . '/') . '/';
@@ -16,7 +16,7 @@ class PrettyOutputPathResolver
 
         if ($type === 'html' && $name !== 'index') {
             if ($page > 1) {
-                return '/' . leftTrimPath(trimPath($path) . '/') . $name . '/' . $page . '/';
+                return '/' . leftTrimPath(trimPath($path) . '/') . $name . '/' . trimPath($prefix . '/' . $page) . '/';
             }
 
             return '/' . leftTrimPath(trimPath($path) . '/') . $name . '/';
@@ -25,15 +25,15 @@ class PrettyOutputPathResolver
         return sprintf('%s%s%s.%s', '/', leftTrimPath(trimPath($path) . '/'), $name, $type);
     }
 
-    public function path($path, $name, $type, $page = 1)
+    public function path($path, $name, $type, $page = 1, $prefix = '')
     {
         if ($type === 'html' && $name === 'index' && $page > 1) {
-            return leftTrimPath(trimPath($path) . '/' . $page . '/' . 'index.html');
+            return leftTrimPath(trimPath($path) . '/' . trimPath($prefix . '/' . $page) . '/' . 'index.html');
         }
 
         if ($type === 'html' && $name !== 'index') {
             if ($page > 1) {
-                return  trimPath($path) . '/' . $name . '/' . $page . '/' . 'index.html';
+                return  trimPath($path) . '/' . $name . '/' . trimPath($prefix . '/' . $page) . '/' . 'index.html';
             }
 
             return trimPath($path) . '/' . $name . '/' . 'index.html';
@@ -46,15 +46,15 @@ class PrettyOutputPathResolver
         return sprintf('%s%s%s.%s', trimPath($path), '/', $name, $type);
     }
 
-    public function directory($path, $name, $type, $page = 1)
+    public function directory($path, $name, $type, $page = 1, $prefix = '')
     {
         if ($type === 'html' && $name === 'index' && $page > 1) {
-            return leftTrimPath(trimPath($path) . '/' . $page);
+            return leftTrimPath(trimPath($path) . '/' . trimPath($prefix . '/' . $page));
         }
 
         if ($type === 'html' && $name !== 'index') {
             if ($page > 1) {
-                return  trimPath($path) . '/' . $name . '/' . $page;
+                return  trimPath($path) . '/' . $name . '/' . trimPath($prefix . '/' . $page);
             }
 
             return trimPath($path) . '/' . $name;

--- a/src/PathResolvers/PrettyOutputPathResolver.php
+++ b/src/PathResolvers/PrettyOutputPathResolver.php
@@ -11,7 +11,7 @@ class PrettyOutputPathResolver
                 return '/' . leftTrimPath(trimPath($path) . '/') . trimPath($prefix . '/' . $page) . '/';
             }
 
-            return  leftTrimPath('/' . trimPath($path) . '/') . '/';
+            return leftTrimPath('/' . trimPath($path) . '/') . '/';
         }
 
         if ($type === 'html' && $name !== 'index') {

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -149,7 +149,7 @@ class SiteBuilder
             return urldecode(dirname($permalink));
         }
 
-        return urldecode($this->outputPathResolver->directory($file->path(), $file->name(), $file->extension(), $file->page()));
+        return urldecode($this->outputPathResolver->directory($file->path(), $file->name(), $file->extension(), $file->page(), $file->prefix()));
     }
 
     private function getOutputPath($file)
@@ -162,7 +162,8 @@ class SiteBuilder
             $file->path(),
             $file->name(),
             $file->extension(),
-            $file->page()
+            $file->page(),
+            $file->prefix()
         )));
     }
 

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -361,9 +361,7 @@ class PaginationTest extends TestCase
         );
     }
 
-        /**
-     * @test
-     */
+    /** @test */
     public function blade_template_file_can_be_paginated_with_prefix()
     {
         $config = collect(['collections' => ['posts' => []]]);
@@ -399,9 +397,7 @@ class PaginationTest extends TestCase
         $this->assertNull($files->getChild('build/blog/3/index.html'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function blade_markdown_template_file_can_be_paginated_with_prefix()
     {
         $config = collect(['collections' => ['posts' => []]]);
@@ -430,9 +426,9 @@ class PaginationTest extends TestCase
 
         $this->buildSite($files, $config, $pretty = true);
 
-        $this->assertEquals('post1post2', $this->clean($files->getChild('build/blog/index.html')->getContent()));
-        $this->assertEquals('post3post4', $this->clean($files->getChild('build/blog/page/2/index.html')->getContent()));
-        $this->assertEquals('post5', $this->clean($files->getChild('build/blog/page/3/index.html')->getContent()));
+        $this->assertSame('post1post2', $this->clean($files->getChild('build/blog/index.html')->getContent()));
+        $this->assertSame('post3post4', $this->clean($files->getChild('build/blog/page/2/index.html')->getContent()));
+        $this->assertSame('post5', $this->clean($files->getChild('build/blog/page/3/index.html')->getContent()));
         $this->assertNull($files->getChild('build/blog/2/index.html'));
         $this->assertNull($files->getChild('build/blog/3/index.html'));
     }

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -360,4 +360,80 @@ class PaginationTest extends TestCase
             $this->clean($files->getChild('build/blog/3/index.html')->getContent())
         );
     }
+
+        /**
+     * @test
+     */
+    public function blade_template_file_can_be_paginated_with_prefix()
+    {
+        $config = collect(['collections' => ['posts' => []]]);
+
+        $files = $this->setupSource([
+            '_layouts' => [
+                'post.blade.php' => "@section('content') @endsection",
+            ],
+            '_posts' => [
+                'post1.blade.php' => "@extends('_layouts.post')1",
+                'post2.blade.php' => "@extends('_layouts.post')2",
+                'post3.blade.php' => "@extends('_layouts.post')3",
+                'post4.blade.php' => "@extends('_layouts.post')4",
+                'post5.blade.php' => "@extends('_layouts.post')5",
+            ],
+            'blog.blade.php' => <<<'BLADE'
+                ---
+                pagination:
+                    collection: posts
+                    perPage: 2
+                    prefix: page
+                ---
+                @foreach($pagination->items as $item){{ $item->getFilename() }}@endforeach
+                BLADE,
+        ]);
+
+        $this->buildSite($files, $config, $pretty = true);
+
+        $this->assertSame('post1post2', $this->clean($files->getChild('build/blog/index.html')->getContent()));
+        $this->assertSame('post3post4', $this->clean($files->getChild('build/blog/page/2/index.html')->getContent()));
+        $this->assertSame('post5', $this->clean($files->getChild('build/blog/page/3/index.html')->getContent()));
+        $this->assertNull($files->getChild('build/blog/2/index.html'));
+        $this->assertNull($files->getChild('build/blog/3/index.html'));
+    }
+
+    /**
+     * @test
+     */
+    public function blade_markdown_template_file_can_be_paginated_with_prefix()
+    {
+        $config = collect(['collections' => ['posts' => []]]);
+
+        $files = $this->setupSource([
+            '_layouts' => [
+                'post.blade.php' => '@section(\'content\') @endsection',
+            ],
+            '_posts' => [
+                'post1.blade.php' => "@extends('_layouts.post')1",
+                'post2.blade.php' => "@extends('_layouts.post')2",
+                'post3.blade.php' => "@extends('_layouts.post')3",
+                'post4.blade.php' => "@extends('_layouts.post')4",
+                'post5.blade.php' => "@extends('_layouts.post')5",
+            ],
+            'blog.blade.md' => <<<'MD'
+                ---
+                pagination:
+                    collection: posts
+                    perPage: 2
+                    prefix: page
+                ---
+                @foreach($pagination->items as $item){{ $item->getFilename() }}@endforeach
+                MD,
+        ]);
+
+        $this->buildSite($files, $config, $pretty = true);
+
+        $this->assertEquals('post1post2', $this->clean($files->getChild('build/blog/index.html')->getContent()));
+        $this->assertEquals('post3post4', $this->clean($files->getChild('build/blog/page/2/index.html')->getContent()));
+        $this->assertEquals('post5', $this->clean($files->getChild('build/blog/page/3/index.html')->getContent()));
+        $this->assertNull($files->getChild('build/blog/2/index.html'));
+        $this->assertNull($files->getChild('build/blog/3/index.html'));
+    }
 }


### PR DESCRIPTION
This PR adds a new pagination property, `prefix`, which allows customizing/prefixing a paginated collection's pages paths. For example, collection items that look like this:

```md
---
pagination:
  collection: posts
  perPage: 2
  prefix: page
---

<!-- Content... -->
```

Will get URLs that look like this:

```
/blog
/blog/page/2
/blog/page/3
etc.
```

Similar to `perPage`, this property can be defined right in the collection item frontmatter, per-collection in the config file, or globally.

@damiani have I missed anywhere pagination stuff is being used? Let me know and I'll add tests and expand this further.

Closes #272.