### PR TITLE
Check for a valid blade extension when handling blade files

### DIFF
--- a/src/Handlers/BladeHandler.php
+++ b/src/Handlers/BladeHandler.php
@@ -2,7 +2,6 @@
 
 namespace TightenCo\Jigsaw\Handlers;
 
-use Illuminate\Support\Str;
 use TightenCo\Jigsaw\File\OutputFile;
 use TightenCo\Jigsaw\File\TemporaryFilesystem;
 use TightenCo\Jigsaw\PageData;
@@ -25,7 +24,8 @@ class BladeHandler
 
     public function shouldHandle($file)
     {
-        return Str::contains($file->getFilename(), '.blade.');
+        // File should have a valid extra blade extension, or be a blade.php file
+        return $file->getExtraBladeExtension() != '' || $file->getFullExtension() == 'blade.php';
     }
 
     public function handleCollectionItem($file, PageData $pageData)

--- a/tests/BladeHandlerTest.php
+++ b/tests/BladeHandlerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests;
+
+use SplFileInfo;
+use TightenCo\Jigsaw\File\InputFile;
+use TightenCo\Jigsaw\Handlers\BladeHandler;
+
+class BladeHandlerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function blade_files_with_invalid_extension_are_not_handled()
+    {
+        $inputFile = new InputFile(new SplFileInfo('foo.blade.swp'));
+        $handler = $this->app->make(BladeHandler::class);
+
+        $this->assertFalse($handler->shouldHandle($inputFile));
+    }
+
+    /**
+     * @test
+     */
+    public function blade_files_with_valid_extensions_are_handled()
+    {
+        $inputFile = new InputFile(new SplFileInfo('foo.blade.txt'));
+        $handler = $this->app->make(BladeHandler::class);
+
+        $this->assertTrue($handler->shouldHandle($inputFile));
+    }
+
+    /**
+     * @test
+     */
+    public function blade_files_with_php_extensions_are_handled()
+    {
+        $inputFile = new InputFile(new SplFileInfo('foo.blade.php'));
+        $handler = $this->app->make(BladeHandler::class);
+
+        $this->assertTrue($handler->shouldHandle($inputFile));
+    }
+}


### PR DESCRIPTION
Blade files without valid exceptions in will cause an exception to be thrown during building. This is particularly noticeable with editor swap files (eg. vim has `.foo.blade.php.swp`) preventing the site from building. (Also reported in #274)

```
❯ ./vendor/bin/jigsaw build

Building local site
Building files from source...


In Factory.php line 291:

  Unrecognized extension in file: /Volumes/Code/home/jigsaw-test/source/foo.blade.bar.


build [--pretty PRETTY] [-c|--cache [CACHE]] [--] [<env>]
```

This PR makes `BladeHandler::shouldHandle` check that the file has a valid extra blade extension (as defined in `extraBladeExtensions`, or a standard `blade.php` extension. If not, it will be rendered by the default handler.

I'm not sure if this is the best approach, as it would silently let unlisted blade extensions pass through without the user being aware of it, but seems better than breaking the build entirely.

Would it possibly be better if we display a warning to the user notifying them of an invalid blade extension instead?