### PR TITLE
Allow merging optional collections file to config file

### DIFF
--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -71,7 +71,7 @@ $container->instance('buildPath', [
 ]);
 
 $container->bind('config', function ($c) use ($cachePath) {
-    $config = (new ConfigFile($c['cwd'] . '/config.php', $c['cwd'] . '/helpers.php'))->config;
+    $config = (new ConfigFile($c['cwd'] . '/config.php', $c['cwd'] . '/helpers.php', $c['cwd'] . '/collections.php'))->config;
     $config->put('view.compiled', $cachePath);
     return $config;
 });

--- a/src/File/ConfigFile.php
+++ b/src/File/ConfigFile.php
@@ -6,12 +6,18 @@ class ConfigFile
 {
     public $config;
 
-    public function __construct(string $config_path, string $helpers_path = '')
+    public function __construct(string $config_path, string $helpers_path = '', string $collections_path = '')
     {
         $config = file_exists($config_path) ? include $config_path : [];
         $helpers = file_exists($helpers_path) ? include $helpers_path : [];
+        $collections = file_exists($collections_path) ? include $collections_path : null;
 
-        $this->config = collect($config)->merge($helpers);
+        $this->config = collect($config)
+            ->merge($helpers)
+            ->when($collections, function ($configs) use ($collections) {
+                return $configs->mergeRecursive(['collections' => $collections]);
+            });
+
         $this->convertStringCollectionsToArray();
     }
 


### PR DESCRIPTION
I often find myself with a lot of collection definitions inside my `config.php` file. Similar to how the `helpers.php` file allows you to offload helper methods to a separate file, this PR would allow you to offload collection definitions to a separate `collections.php` file.

I have accounted for the following scenarios:

- Collections defined only in `config.php`
- Collections defined only in `collections.php`
- Collections defined in both `config.php` and `collections.php`

I looked into adding tests for this (and also for the currently untested `helpers.php` file) but it would require adding a `collections.php` file to the root directory (likewise with a `helpers.php` file). While I'm not opposed to doing that, I wasn't sure how you might want to handle this.

Note that the root directory doesn't contain a `config.php`, but instead contains a `config.testing.php` (reflecting the environment). The existing `helpers.php` file integration doesn't account for the environment variable like this - and I wanted my `collections.php` integration to work in a similar fashion.