### PR TITLE
Allow invokeable event listeners

### DIFF
--- a/src/Events/EventBus.php
+++ b/src/Events/EventBus.php
@@ -2,6 +2,7 @@
 
 namespace TightenCo\Jigsaw\Events;
 
+use Illuminate\Support\Arr;
 use TightenCo\Jigsaw\Jigsaw;
 
 class EventBus
@@ -20,11 +21,7 @@ class EventBus
     public function __call($event, $arguments)
     {
         if (isset($this->{$event})) {
-            $listeners = $arguments[0];
-            if ( ! is_array($listeners)) {
-                $listeners = [$listeners];
-            }
-            $this->{$event} = $this->{$event}->merge(collect($listeners));
+            $this->{$event} = $this->{$event}->merge(collect(Arr::wrap($arguments[0])));
         }
     }
 

--- a/src/Events/EventBus.php
+++ b/src/Events/EventBus.php
@@ -20,7 +20,7 @@ class EventBus
     public function __call($event, $arguments)
     {
         if (isset($this->{$event})) {
-            $this->{$event} = $this->{$event}->merge(collect($arguments[0]));
+            $this->{$event}->add(current($arguments));
         }
     }
 

--- a/src/Events/EventBus.php
+++ b/src/Events/EventBus.php
@@ -20,7 +20,11 @@ class EventBus
     public function __call($event, $arguments)
     {
         if (isset($this->{$event})) {
-            $this->{$event}->add(current($arguments));
+            $listeners = $arguments[0];
+            if ( ! is_array($listeners)) {
+                $listeners = [$listeners];
+            }
+            $this->{$event} = $this->{$event}->merge(collect($listeners));
         }
     }
 

--- a/src/Events/EventBus.php
+++ b/src/Events/EventBus.php
@@ -21,7 +21,7 @@ class EventBus
     public function __call($event, $arguments)
     {
         if (isset($this->{$event})) {
-            $this->{$event} = $this->{$event}->merge(collect(Arr::wrap($arguments[0])));
+            $this->{$event} = $this->{$event}->merge(Arr::wrap($arguments[0]));
         }
     }
 

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -54,6 +54,26 @@ class EventsTest extends TestCase
         $this->assertEquals('set in TestListener', $jigsaw->getConfig('variable_b'));
     }
 
+    /** @test */
+    public function it_can_handle_invokable_listeners()
+    {
+        $this->app['events']->beforeBuild(new class {
+            private $object;
+
+            public function __construct()
+            {
+                $this->object = (object) [];
+            }
+
+            public function __invoke($jigsaw) {
+                $jigsaw->setConfig('variable_a', 'Set from invokable');
+            }
+        });
+        $jigsaw = $this->buildSite($this->setupSource(), ['variable_a' => 'set in config.php']);
+
+        $this->assertEquals('Set from invokable', $jigsaw->getConfig('variable_a'));
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
Hi, 

There is a slight issue with the `EventBus`. When you add a listener to the event collection, it creates a new collection by merging with a `collect($arguments[0])` call. This has some unforeseen side effects when you use an invokable event listener with an internal object.

```php
$events->afterCollections(new class {
    private $object;

    public function __construct()
    {
        $this->object = (object) [];
    }

    public function __invoke(Jigsaw $jigsaw) {
        dump($jigsaw);
    }
});
```

This example will currently throw an error:

```bash
PHP Fatal error:  Uncaught Error: Call to undefined method stdClass::handle() in /Users/doekenorg/code/doekenorg/vendor/tightenco/jigsaw/src/Events/EventBus.php:33
```

This update will fix that problem, by just appending the first argument to the collection that already exists. No merging required. 


