### PR TITLE
Add support for PHP 8.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,44 +1,23 @@
 name: CI
-
 on:
   push:
-    branches: [master]
+    branches: [main, ci]
   pull_request:
-
 jobs:
   test:
-    name: Test (PHP ${{ matrix.php }})
-
+    name: PHP ${{ matrix.php }}, ${{ matrix.dependencies }}
     runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4, 8.0]
-        include:
-          - front-yaml: '^1.8'
-            phpunit: '^9.0'
-
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        dependencies: [lowest, highest]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-
-      - name: Cache dependencies
-        uses: actions/cache@v1
+      - uses: ramsey/composer-install@v2
         with:
-          path: ~/.composer/cache/files
-          key: php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: php-${{ matrix.php }}-composer-
-
-      - name: Install dependencies
-        run: |
-          composer require "mnapoli/front-yaml:${{ matrix.front-yaml }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
-          composer install --no-interaction
-
-      - name: Run PHPUnit tests
-        run: vendor/bin/phpunit --testdox --colors=always
+          dependency-versions: ${{ matrix.dependencies }}
+      - run: vendor/bin/phpunit --testdox --colors=always

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['7.3', '7.4', '8.0', '8.1']
         dependencies: [lowest, highest]
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ~8.0.0 || ~8.1.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "illuminate/collections": "^8.53",
         "illuminate/container": "^8.53",
         "illuminate/filesystem": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,16 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ~8.0 || ~8.1",
-        "illuminate/collections": "^8.80",
-        "illuminate/container": "^8.80",
-        "illuminate/contracts": "^8.80",
-        "illuminate/filesystem": "^8.80",
-        "illuminate/support": "^8.80",
-        "illuminate/view": "^8.80",
+        "php": "^7.2 || ~8.0.0 || ~8.1.0",
+        "illuminate/collections": "^8.53",
+        "illuminate/container": "^8.53",
+        "illuminate/filesystem": "^8.0",
+        "illuminate/support": "^8.53",
+        "illuminate/view": "^8.53",
         "michelf/php-markdown": "^1.9",
         "mnapoli/front-yaml": "^1.5",
         "symfony/console": "^4.4.30 || ^5.4",
+        "symfony/finder": "^4.0 || ^5.3.7",
         "symfony/process": "^4.0 || ^5.0",
         "symfony/var-dumper": "^4.4.29 || ^5.0",
         "symfony/yaml": "^4.0 || ^5.0",
@@ -33,7 +33,7 @@
         "friendsofphp/php-cs-fixer": "^2.12",
         "mikey179/vfsstream": "^1.6.10",
         "mockery/mockery": "^1.4",
-        "phpunit/phpunit": "~7.0 || ^9.3.3"
+        "phpunit/phpunit": "^9.3.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
         "friendsofphp/php-cs-fixer": "^2.12",
         "mikey179/vfsstream": "^1.6.10",
         "mockery/mockery": "^1.4",
-        "phpunit/phpunit": "~7.0 || ^9.3.3",
-        "spatie/ray": "^1.33"
+        "phpunit/phpunit": "~7.0 || ^9.3.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,23 +14,27 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
-        "illuminate/container": "^8.0",
-        "illuminate/support": "^8.0",
-        "illuminate/view": "^8.0",
+        "php": "^7.2 || ~8.0 || ~8.1",
+        "illuminate/collections": "^8.80",
+        "illuminate/container": "^8.80",
+        "illuminate/contracts": "^8.80",
+        "illuminate/filesystem": "^8.80",
+        "illuminate/support": "^8.80",
+        "illuminate/view": "^8.80",
         "michelf/php-markdown": "^1.9",
-        "mnapoli/front-yaml": "^1.5|^1.8",
-        "mockery/mockery": "^1.0.0",
-        "symfony/console": "^4.0|^5.0",
-        "symfony/process": "^4.0|^5.0",
-        "symfony/var-dumper": "^4.0|^5.0",
-        "symfony/yaml": "^4.0|^5.0",
-        "vlucas/phpdotenv": "^5.3"
+        "mnapoli/front-yaml": "^1.5",
+        "symfony/console": "^4.4.30 || ^5.4",
+        "symfony/process": "^4.0 || ^5.0",
+        "symfony/var-dumper": "^4.4.29 || ^5.0",
+        "symfony/yaml": "^4.0 || ^5.0",
+        "vlucas/phpdotenv": "^5.3.1"
     },
     "require-dev": {
-        "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "~7.0|^9.3.3",
-        "friendsofphp/php-cs-fixer": "^2.12"
+        "friendsofphp/php-cs-fixer": "^2.12",
+        "mikey179/vfsstream": "^1.6.10",
+        "mockery/mockery": "^1.4",
+        "phpunit/phpunit": "~7.0 || ^9.3.3",
+        "spatie/ray": "^1.33"
     },
     "autoload": {
         "psr-4": {

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -98,7 +98,7 @@ class BuildCommand extends Command
             ? $this->getAbsolutePath($customPath)
             :  Arr::get($this->app->buildPath, $pathType);
 
-        return str_replace('{env}', $env, $buildPath);
+        return str_replace('{env}', $env, $buildPath ?? '');
     }
 
     private function getAbsolutePath($path)

--- a/src/IterableObject.php
+++ b/src/IterableObject.php
@@ -46,17 +46,6 @@ class IterableObject extends BaseCollection implements ArrayAccess
         return true;
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetGet($key)
-    {
-        if (! isset($this->items[$key])) {
-            $prefix = $this->_source ? 'Error in ' . $this->_source . ': ' : 'Error: ';
-            throw new Exception($prefix . "The key '$key' does not exist.");
-        }
-
-        return $this->getElement($key);
-    }
-
     public function set($key, $value)
     {
         data_set($this->items, $key, $this->isArrayable($value) ? $this->makeIterable($value) : $value);
@@ -69,6 +58,17 @@ class IterableObject extends BaseCollection implements ArrayAccess
     public function putIterable($key, $element)
     {
         $this->put($key, $this->isArrayable($element) ? $this->makeIterable($element) : $element);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetGet($key)
+    {
+        if (! isset($this->items[$key])) {
+            $prefix = $this->_source ? 'Error in ' . $this->_source . ': ' : 'Error: ';
+            throw new Exception($prefix . "The key '$key' does not exist.");
+        }
+
+        return $this->getElement($key);
     }
 
     protected function getElement($key)

--- a/src/IterableObject.php
+++ b/src/IterableObject.php
@@ -19,6 +19,11 @@ class IterableObject extends BaseCollection implements ArrayAccess
         return $this->get($key);
     }
 
+    public function except($keys)
+    {
+        return is_null($keys) ? $this : parent::except($keys);
+    }
+
     public function get($key, $default = null)
     {
         if (array_key_exists($key, $this->items)) {

--- a/src/IterableObject.php
+++ b/src/IterableObject.php
@@ -33,6 +33,19 @@ class IterableObject extends BaseCollection implements ArrayAccess
         return value($default);
     }
 
+    public function has($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if (! array_key_exists($value, $this->items)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -13,7 +13,7 @@ function leftTrimPath($path)
 
 function rightTrimPath($path)
 {
-    return rtrim($path, ' .\\/');
+    return rtrim($path ?? '', ' .\\/');
 }
 
 function trimPath($path)

--- a/tests/config.php
+++ b/tests/config.php
@@ -34,7 +34,7 @@ return [
     ],
     'envVariable' => env('JIGSAW_TEST_VAR', false),
     'globalPreview' => function ($data, $characters = 100) {
-        return substr(strip_tags($data->getContent()), 0, $characters);
+        return substr(strip_tags($data->getContent() ?? ''), 0, $characters);
     },
     'helperFunction' => function ($data) {
         return 'hello global! #' . $data->number;
@@ -89,7 +89,7 @@ return [
                 return sprintf('%s/%s/%s', $month, $day, $year);
             },
             'preview' => function ($post, $characters = 75) {
-                return substr(strip_tags($post->getContent()), 0, $characters);
+                return substr(strip_tags($post->getContent() ?? ''), 0, $characters);
             },
             'api' => function ($post) {
                 return [
@@ -119,7 +119,7 @@ return [
                     'name' => $data->name,
                     'number' => $data->number,
                     'role' => $data->role,
-                    'content' => strip_tags($data->getContent()),
+                    'content' => strip_tags($data->getContent() ?? ''),
                 ])->toJson();
             },
         ],


### PR DESCRIPTION
Adds support for PHP 8.1:

- Bump minimum versions of some dependencies.
- Default some arguments to an empty string where passing `null` is deprecated.
- Override the base Collection `except` method to handle null being passed in.
- Override the base Collection `has` method to use `array_key_exists` instead of `offsetExists` (may not be absolutely necessary but maintains consistency with Illuminate 7 bevahiour, see #571).

Also:

- Add test matrix runs on PHP 8.1 and with minimum possible dependency versions.
- Explicitly drop support for PHP 7.2 (Illuminate 8 requires `^7.3`). This isn't a breaking change, right? People who absolutely need to stay on PHP 7.2 just can't upgrade?

Closes #601.