### PR TITLE
feat: add event bus type hints

### DIFF
--- a/src/Events/EventBus.php
+++ b/src/Events/EventBus.php
@@ -3,13 +3,19 @@
 namespace TightenCo\Jigsaw\Events;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use TightenCo\Jigsaw\Jigsaw;
 
+/**
+ * @method void beforeBuild(\callable|class-string|array<int, class-string> $callable)
+ * @method void afterCollections(\callable|class-string|array<int, class-string> $callable)
+ * @method void afterBuild(\callable|class-string|array<int, class-string> $callable)
+ */
 class EventBus
 {
-    public $beforeBuild;
-    public $afterCollections;
-    public $afterBuild;
+    public Collection $beforeBuild;
+    public Collection $afterCollections;
+    public Collection $afterBuild;
 
     public function __construct()
     {

--- a/src/Events/EventBus.php
+++ b/src/Events/EventBus.php
@@ -7,9 +7,9 @@ use Illuminate\Support\Collection;
 use TightenCo\Jigsaw\Jigsaw;
 
 /**
- * @method void beforeBuild(\callable|class-string|array<int, class-string> $callable)
- * @method void afterCollections(\callable|class-string|array<int, class-string> $callable)
- * @method void afterBuild(\callable|class-string|array<int, class-string> $callable)
+ * @method void beforeBuild(\callable|class-string|array<int, class-string> $listener)
+ * @method void afterCollections(\callable|class-string|array<int, class-string> $listener)
+ * @method void afterBuild(\callable|class-string|array<int, class-string> $listener)
  */
 class EventBus
 {


### PR DESCRIPTION
I was recently adding some event listeners to a Jigsaw site and noticed that PHPStan complains that these methods don't exist on the `EventBus` instance. 👍🏻

I also added the `Collection` type to the 3 properties as they are always that type (but I'm happy to remove that).