### PR TITLE
Improve serve command option handling

### DIFF
--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -58,7 +58,11 @@ class ServeCommand extends Command
 
         if (! $this->input->getOption('no-build')) {
             $buildCmd = $this->getApplication()->find('build');
-            $buildArgs = new ArrayInput(['env' => $env]);
+            $buildArgs = new ArrayInput([
+                'env' => $env,
+                '--quiet' => $this->input->getOption('quiet'),
+                '--verbose' => $this->input->getOption('verbose'),
+            ]);
             $buildCmd->run($buildArgs, $this->output);
         }
 


### PR DESCRIPTION
This allows us to call `jigsaw serve` command with `-q` or `-vv` options and it will work just like `jigsaw build` command. 👍

Currently if you use a custom build path and run `jigsaw serve -q` it does not ask for a confirmation nor continue - it's kinda broken. 😄