### PR TITLE
Allow filename.md.blade.php

### DIFF
--- a/src/View/ViewRenderer.php
+++ b/src/View/ViewRenderer.php
@@ -19,6 +19,7 @@ class ViewRenderer
         'blade.md' => 'blade-markdown',
         'blade.mdown' => 'blade-markdown',
         'blade.markdown' => 'blade-markdown',
+        'md.blade.php' => 'blade-markdown',
     ];
     private $bladeExtensions = [
         'js', 'json', 'xml', 'yaml', 'yml', 'rss', 'atom', 'txt', 'text', 'html',


### PR DESCRIPTION
When working with blade, editing is more easy when using .blade.php.

This addition will allow us to continue using markdown, but also having the benefit of autocomplete in editors.