### PR TITLE
Fix Blade files without `extends` overwriting other pages

### DIFF
--- a/src/Handlers/CollectionItemHandler.php
+++ b/src/Handlers/CollectionItemHandler.php
@@ -60,14 +60,14 @@ class CollectionItemHandler
 
                 $path = $outputFile->data()->page->getPath();
 
-                return new OutputFile(
+                return $path ? new OutputFile(
                     $file,
                     dirname($path),
                     basename($path, '.' . $outputFile->extension()),
                     $outputFile->extension(),
                     $outputFile->contents(),
                     $outputFile->data(),
-                );
-            })->values();
+                ) : null;
+            })->filter()->values();
     }
 }

--- a/tests/SnapshotsTest.php
+++ b/tests/SnapshotsTest.php
@@ -32,7 +32,7 @@ class SnapshotsTest extends PHPUnit
             ->reject(fn ($name) => Str::endsWith($name, '_snapshot'))
             // Prepend the test command with JIGSAW_SNAPSHOTS=<snapshot-names> to run specific snapshot tests
             ->when(isset($_SERVER['JIGSAW_SNAPSHOTS']), fn ($directories) => $directories->filter(
-                fn ($name) => in_array($name, explode(',', $_SERVER['JIGSAW_SNAPSHOTS']))
+                fn ($name) => in_array($name, explode(',', $_SERVER['JIGSAW_SNAPSHOTS'])),
             ))
             ->mapWithKeys(fn ($name) => [$name => [$name]])
             ->all();

--- a/tests/snapshots/blade-no-extends/config.php
+++ b/tests/snapshots/blade-no-extends/config.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'collections' => [
+        'pages',
+    ],
+];

--- a/tests/snapshots/blade-no-extends/source/_layouts/main.blade.php
+++ b/tests/snapshots/blade-no-extends/source/_layouts/main.blade.php
@@ -1,0 +1,6 @@
+<div>
+    <p>MAIN LAYOUT</p>
+    <div>
+        @yield('body')
+    </div>
+</div>

--- a/tests/snapshots/blade-no-extends/source/_pages/page-a-markdown.md
+++ b/tests/snapshots/blade-no-extends/source/_pages/page-a-markdown.md
@@ -1,0 +1,5 @@
+---
+extends: _layouts.main
+section: body
+---
+Regular markdown with extends and section.

--- a/tests/snapshots/blade-no-extends/source/_pages/page-b-nothing.blade.php
+++ b/tests/snapshots/blade-no-extends/source/_pages/page-b-nothing.blade.php
@@ -1,0 +1,3 @@
+@foreach ([1] as $i)
+No extends or section, does not render.
+@endforeach

--- a/tests/snapshots/blade-no-extends/source/_pages/page-c-empty.blade.php
+++ b/tests/snapshots/blade-no-extends/source/_pages/page-c-empty.blade.php
@@ -1,0 +1,6 @@
+---
+foo: bar
+---
+@foreach ([1] as $i)
+Frontmatter with no extends or section, does not render.
+@endforeach

--- a/tests/snapshots/blade-no-extends/source/_pages/page-d-extends.blade.php
+++ b/tests/snapshots/blade-no-extends/source/_pages/page-d-extends.blade.php
@@ -1,0 +1,6 @@
+---
+extends: _layouts.main
+---
+@foreach ([1] as $i)
+Extends but no section, renders incorrectly (at the top of the file, intead of at the `yield` directive).
+@endforeach

--- a/tests/snapshots/blade-no-extends/source/index.blade.php
+++ b/tests/snapshots/blade-no-extends/source/index.blade.php
@@ -1,0 +1,5 @@
+@extends('_layouts.main')
+
+@section('body')
+Hello world!
+@endsection

--- a/tests/snapshots/blade-no-extends_snapshot/index.html
+++ b/tests/snapshots/blade-no-extends_snapshot/index.html
@@ -1,0 +1,6 @@
+<div>
+    <p>MAIN LAYOUT</p>
+    <div>
+        Hello world!
+    </div>
+</div>

--- a/tests/snapshots/blade-no-extends_snapshot/pages/page-a-markdown/index.html
+++ b/tests/snapshots/blade-no-extends_snapshot/pages/page-a-markdown/index.html
@@ -1,0 +1,6 @@
+<div>
+    <p>MAIN LAYOUT</p>
+    <div>
+        <p>Regular markdown with extends and section.</p>
+    </div>
+</div>

--- a/tests/snapshots/blade-no-extends_snapshot/pages/page-d-extends/index.html
+++ b/tests/snapshots/blade-no-extends_snapshot/pages/page-d-extends/index.html
@@ -1,0 +1,7 @@
+Extends but no section, renders incorrectly (at the top of the file, intead of at the `yield` directive).
+
+<div>
+    <p>MAIN LAYOUT</p>
+    <div>
+            </div>
+</div>


### PR DESCRIPTION
Blade files that don't extend a parent template should never be rendered. In some cases we were rendering them anyway, and because they don't have a template or path, their output path defaulted to `''`, overwriting the root `index.html` page or creating a root `.html` page.

This PR ensures that we don't create an `OutputFile` for files we don't want to render.

Closes #670.