### PR TITLE
Add support for Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/support": "^9.0 || ^10.0",
         "illuminate/view": "^9.8 || ^10.0",
         "michelf/php-markdown": "^1.9 || ^2.0",
-        "mnapoli/front-yaml": "^1.5 || ^2.0",
+        "mnapoli/front-yaml": "^2.0",
         "nunomaduro/collision": "^6.1",
         "spatie/laravel-ignition": "^1.6 || ^2.0",
         "symfony/console": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -15,22 +15,22 @@
     ],
     "require": {
         "php": "^8.0.2 <8.4",
-        "illuminate/collections": "^9.0",
-        "illuminate/console": "^9.21.1",
-        "illuminate/container": "^9.0",
-        "illuminate/filesystem": "^9.0",
-        "illuminate/support": "^9.0",
-        "illuminate/view": "^9.8",
-        "michelf/php-markdown": "^1.9",
-        "mnapoli/front-yaml": "^1.5",
-        "nunomaduro/collision": "^6.0",
-        "spatie/laravel-ignition": "^1.6",
-        "symfony/console": "^5.4 || ^6.0",
-        "symfony/error-handler": "^5.0 || ^6.0",
-        "symfony/finder": "^5.3.7 || ^6.0",
-        "symfony/process": "^5.0 || ^6.0",
-        "symfony/var-dumper": "^5.0 || ^6.0",
-        "symfony/yaml": "^5.0 || ^6.0",
+        "illuminate/collections": "^9.0 || ^10.0",
+        "illuminate/console": "^9.21.1 || ^10.0",
+        "illuminate/container": "^9.0 || ^10.0",
+        "illuminate/filesystem": "^9.0 || ^10.0",
+        "illuminate/support": "^9.0 || ^10.0",
+        "illuminate/view": "^9.8 || ^10.0",
+        "michelf/php-markdown": "^1.9 || ^2.0",
+        "mnapoli/front-yaml": "^1.5 || ^2.0",
+        "nunomaduro/collision": "^6.1",
+        "spatie/laravel-ignition": "^1.6 || ^2.0",
+        "symfony/console": "^6.0",
+        "symfony/error-handler": "^6.0",
+        "symfony/finder": "^6.0",
+        "symfony/process": "^6.0",
+        "symfony/var-dumper": "^6.0",
+        "symfony/yaml": "^6.0",
         "vlucas/phpdotenv": "^5.3.1"
     },
     "require-dev": {
@@ -56,7 +56,7 @@
         "jigsaw"
     ],
     "scripts": {
-        "format" : "php-cs-fixer fix --verbose"
+        "format": "php-cs-fixer fix --verbose"
     },
     "config": {
         "sort-packages": true,

--- a/src/Parsers/MarkdownParser.php
+++ b/src/Parsers/MarkdownParser.php
@@ -23,7 +23,7 @@ class MarkdownParser implements FrontYAMLMarkdownParser
         $this->parser->$property = $value;
     }
 
-    public function parse($markdown)
+    public function parse(string $markdown): string
     {
         return $this->parser->parse($markdown);
     }


### PR DESCRIPTION
This supersedes [#676](https://github.com/tighten/jigsaw/pull/676) by ensuring both Laravel 9 and Laravel 10 are supported. 

In addition, it sets the minimum requirement for Symfony dependencies to `^6.0` as that was the minimum required by Laravel 9.