### PR TITLE
Collection path: optional transliterate

### DIFF
--- a/src/Loaders/CollectionDataLoader.php
+++ b/src/Loaders/CollectionDataLoader.php
@@ -80,7 +80,7 @@ class CollectionDataLoader
             ->merge($collection->settings)
             ->merge($this->getHandler($file)->getItemVariables($file));
         $data->put('_meta', new IterableObject($this->getMetaData($file, $collection, $data)));
-        $path = $this->getPath($data);
+        $path = $this->getPath($data, $collection);
         $data->_meta->put('path', $path)->put('url', $this->buildUrls($path));
 
         return CollectionItem::build($collection, $data);
@@ -134,9 +134,9 @@ class CollectionDataLoader
         return $urls->count() ? new IterableObjectWithDefault($urls) : null;
     }
 
-    private function getPath($data)
+    private function getPath($data, $collection)
     {
-        $links = $this->pathResolver->link($data->path, new PageVariable($data));
+        $links = $this->pathResolver->link($data->path, new PageVariable($data), $collection);
 
         return $links->count() ? new IterableObjectWithDefault($links) : null;
     }

--- a/src/PathResolvers/CollectionPathResolver.php
+++ b/src/PathResolvers/CollectionPathResolver.php
@@ -16,11 +16,12 @@ class CollectionPathResolver
         $this->view = $viewRenderer;
     }
 
-    public function link($path, $data)
+    public function link($path, $data, $collection)
     {
-        return collect($data->extends)->map(function ($bladeViewPath, $templateKey) use ($path, $data) {
+        return collect($data->extends)->map(function ($bladeViewPath, $templateKey) use ($path, $data, $collection) {
             return $this->cleanOutputPath(
                 $this->getPath($path, $data, $this->getExtension($bladeViewPath), $templateKey),
+                Arr::get($collection->settings, 'transliterate', true)
             );
         });
     }
@@ -117,12 +118,16 @@ class CollectionPathResolver
         return $this->ensureSlashAtBeginningOnly($path);
     }
 
-    private function cleanOutputPath($path)
+    private function cleanOutputPath($path, $transliterate=true)
     {
-        $removeDoubleSlashes = preg_replace('/\/\/+/', '/', $path);
-        $transliterate = $this->ascii($removeDoubleSlashes);
+        // remove double slashes
+        $path = preg_replace('/\/\/+/', '/', $path);
 
-        return $this->ensureSlashAtBeginningOnly($transliterate);
+        if($transliterate) {
+            $path = $this->ascii($path);
+        }
+
+        return $this->ensureSlashAtBeginningOnly($path);
     }
 
     private function ensureSlashAtBeginningOnly($path)


### PR DESCRIPTION
Currently collection item paths are transliterated by default with no option to disable this behaviour. This PR makes this behaviour optional while retaining the default behaviour so no breaking changes are introduced.

The `transliterate` option can be added to a collection's config.

```php
return [
    'collections' => [
        'posts' => [
            'transliterate' => false,
            'extends' => '_layouts/main',
            'path' => 'مقال/{filename}',

            'items' => [
                [
                    'filename' => 'جزيرة-الكنز',
                    'content' => '',
                ],
                [
                    'filename' => 'الكابتن-ماجد',
                    'content' => '',
                ],
            ]
        ]
    ],
];
```

---

It seems _only_ collection item paths are transliterated. So the default behaviour for collection items vs normal pages paths is not identical. This PR doesn't address this. This could be something to address in [v2.0](https://github.com/tighten/jigsaw/issues?q=is%3Aopen+is%3Aissue+milestone%3Av2.0)?