### PR TITLE
Allow setting collections using a function

### DIFF
--- a/src/File/ConfigFile.php
+++ b/src/File/ConfigFile.php
@@ -17,7 +17,7 @@ class ConfigFile
 
     protected function convertStringCollectionsToArray()
     {
-        $collections = $this->config->get('collections');
+        $collections = value($this->config->get('collections'));
 
         if ($collections) {
             $this->config->put('collections', collect($collections)->flatMap(function ($value, $key) {

--- a/tests/RemoteCollectionsTest.php
+++ b/tests/RemoteCollectionsTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests;
 
+use Illuminate\Support\Arr;
+
 class RemoteCollectionsTest extends TestCase
 {
     /**
@@ -655,6 +657,41 @@ class RemoteCollectionsTest extends TestCase
         $this->assertEquals(
             '<div><p>Hey there</p></div>',
             $this->clean($files->getChild('build/test/test-1.html')->getContent()),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function collections_key_in_config_can_be_a_function_that_returns_a_list_of_collections()
+    {
+        $config = collect([
+            'collections' => fn () => [
+                'test' => [
+                    'extends' => '_layouts.master',
+                    'items' => function () {
+                        return collect([
+                            ['content' => 'item 1'],
+                            ['content' => 'item 2'],
+                        ]);
+                    },
+                ],
+            ],
+        ]);
+        $files = $this->setupSource([
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
+            ],
+        ]);
+        $this->buildSite($files, $config);
+
+        $this->assertEquals(
+            '<div><p>item 1</p></div>',
+            $this->clean($files->getChild('build/test/test-1.html')->getContent()),
+        );
+        $this->assertEquals(
+            '<div><p>item 2</p></div>',
+            $this->clean($files->getChild('build/test/test-2.html')->getContent()),
         );
     }
 }

--- a/tests/RemoteCollectionsTest.php
+++ b/tests/RemoteCollectionsTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests;
 
-use Illuminate\Support\Arr;
-
 class RemoteCollectionsTest extends TestCase
 {
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -108,6 +108,14 @@ class TestCase extends BaseTestCase
     {
         $this->app->consoleOutput->setup($verbosity = -1);
         $this->app->config = collect($this->app->config)->merge($config);
+
+        $collections = value($this->app->config->get('collections'));
+
+        if ($collections) {
+            $this->app->config->put('collections', collect($collections)->flatMap(function ($value, $key) {
+                return is_array($value) ? [$key => $value] : [$value => []];
+            }));
+        }
         $this->app->buildPath = [
             'source' => $vfs->url() . '/source',
             'views' => $vfs->url() . $viewPath,


### PR DESCRIPTION
This PR addresses the issue https://github.com/tighten/jigsaw/issues/572

It allows us to set the collection using a function. 

It means that now it is possible to get the collections and entries from an external API dynamically without having to expressly set the collections. 