### PR TITLE
Allow setting collections using a function

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -154,8 +154,8 @@ class Container extends Illuminate
     private function registerCoreProviders(): void
     {
         foreach ([
-                     Providers\EventServiceProvider::class,
-                 ] as $provider) {
+             Providers\EventServiceProvider::class,
+         ] as $provider) {
             ($provider = new $provider($this))->register();
 
             $this->providers[] = $provider;
@@ -165,14 +165,14 @@ class Container extends Illuminate
     private function registerConfiguredProviders(): void
     {
         foreach ([
-                     Providers\ExceptionServiceProvider::class,
-                     Providers\FilesystemServiceProvider::class,
-                     Providers\MarkdownServiceProvider::class,
-                     Providers\ViewServiceProvider::class,
-                     Providers\CollectionServiceProvider::class,
-                     Providers\CompatibilityServiceProvider::class,
-                     Providers\BootstrapFileServiceProvider::class,
-                 ] as $provider) {
+             Providers\ExceptionServiceProvider::class,
+             Providers\FilesystemServiceProvider::class,
+             Providers\MarkdownServiceProvider::class,
+             Providers\ViewServiceProvider::class,
+             Providers\CollectionServiceProvider::class,
+             Providers\CompatibilityServiceProvider::class,
+             Providers\BootstrapFileServiceProvider::class,
+         ] as $provider) {
             ($provider = new $provider($this))->register();
 
             $this->providers[] = $provider;
@@ -182,9 +182,9 @@ class Container extends Illuminate
     private function registerCoreAliases(): void
     {
         foreach ([
-                     'app' => [self::class, \Illuminate\Contracts\Container\Container::class, \Psr\Container\ContainerInterface::class],
-                     'view' => [\Illuminate\View\Factory::class, \Illuminate\Contracts\View\Factory::class],
-                 ] as $key => $aliases) {
+             'app' => [self::class, \Illuminate\Contracts\Container\Container::class, \Psr\Container\ContainerInterface::class],
+             'view' => [\Illuminate\View\Factory::class, \Illuminate\Contracts\View\Factory::class],
+         ] as $key => $aliases) {
             foreach ($aliases as $alias) {
                 $this->alias($key, $alias);
             }

--- a/src/Container.php
+++ b/src/Container.php
@@ -154,8 +154,8 @@ class Container extends Illuminate
     private function registerCoreProviders(): void
     {
         foreach ([
-             Providers\EventServiceProvider::class,
-         ] as $provider) {
+            Providers\EventServiceProvider::class,
+        ] as $provider) {
             ($provider = new $provider($this))->register();
 
             $this->providers[] = $provider;
@@ -165,14 +165,14 @@ class Container extends Illuminate
     private function registerConfiguredProviders(): void
     {
         foreach ([
-             Providers\ExceptionServiceProvider::class,
-             Providers\FilesystemServiceProvider::class,
-             Providers\MarkdownServiceProvider::class,
-             Providers\ViewServiceProvider::class,
-             Providers\CollectionServiceProvider::class,
-             Providers\CompatibilityServiceProvider::class,
-             Providers\BootstrapFileServiceProvider::class,
-         ] as $provider) {
+            Providers\ExceptionServiceProvider::class,
+            Providers\FilesystemServiceProvider::class,
+            Providers\MarkdownServiceProvider::class,
+            Providers\ViewServiceProvider::class,
+            Providers\CollectionServiceProvider::class,
+            Providers\CompatibilityServiceProvider::class,
+            Providers\BootstrapFileServiceProvider::class,
+        ] as $provider) {
             ($provider = new $provider($this))->register();
 
             $this->providers[] = $provider;
@@ -182,9 +182,9 @@ class Container extends Illuminate
     private function registerCoreAliases(): void
     {
         foreach ([
-             'app' => [self::class, \Illuminate\Contracts\Container\Container::class, \Psr\Container\ContainerInterface::class],
-             'view' => [\Illuminate\View\Factory::class, \Illuminate\Contracts\View\Factory::class],
-         ] as $key => $aliases) {
+            'app' => [self::class, \Illuminate\Contracts\Container\Container::class, \Psr\Container\ContainerInterface::class],
+            'view' => [\Illuminate\View\Factory::class, \Illuminate\Contracts\View\Factory::class],
+        ] as $key => $aliases) {
             foreach ($aliases as $alias) {
                 $this->alias($key, $alias);
             }

--- a/src/Container.php
+++ b/src/Container.php
@@ -106,8 +106,8 @@ class Container extends Illuminate
             $config = $config->merge(require $path);
         }
 
-        if ($config->get('collections')) {
-            $config->put('collections', collect($config->get('collections'))->flatMap(
+        if ($collections = value($config->get('collections'))) {
+            $config->put('collections', collect($collections)->flatMap(
                 fn ($value, $key) => is_array($value) ? [$key => $value] : [$value => []],
             ));
         }
@@ -154,8 +154,8 @@ class Container extends Illuminate
     private function registerCoreProviders(): void
     {
         foreach ([
-            Providers\EventServiceProvider::class,
-        ] as $provider) {
+                     Providers\EventServiceProvider::class,
+                 ] as $provider) {
             ($provider = new $provider($this))->register();
 
             $this->providers[] = $provider;
@@ -165,14 +165,14 @@ class Container extends Illuminate
     private function registerConfiguredProviders(): void
     {
         foreach ([
-            Providers\ExceptionServiceProvider::class,
-            Providers\FilesystemServiceProvider::class,
-            Providers\MarkdownServiceProvider::class,
-            Providers\ViewServiceProvider::class,
-            Providers\CollectionServiceProvider::class,
-            Providers\CompatibilityServiceProvider::class,
-            Providers\BootstrapFileServiceProvider::class,
-        ] as $provider) {
+                     Providers\ExceptionServiceProvider::class,
+                     Providers\FilesystemServiceProvider::class,
+                     Providers\MarkdownServiceProvider::class,
+                     Providers\ViewServiceProvider::class,
+                     Providers\CollectionServiceProvider::class,
+                     Providers\CompatibilityServiceProvider::class,
+                     Providers\BootstrapFileServiceProvider::class,
+                 ] as $provider) {
             ($provider = new $provider($this))->register();
 
             $this->providers[] = $provider;
@@ -182,9 +182,9 @@ class Container extends Illuminate
     private function registerCoreAliases(): void
     {
         foreach ([
-            'app' => [self::class, \Illuminate\Contracts\Container\Container::class, \Psr\Container\ContainerInterface::class],
-            'view' => [\Illuminate\View\Factory::class, \Illuminate\Contracts\View\Factory::class],
-        ] as $key => $aliases) {
+                     'app' => [self::class, \Illuminate\Contracts\Container\Container::class, \Psr\Container\ContainerInterface::class],
+                     'view' => [\Illuminate\View\Factory::class, \Illuminate\Contracts\View\Factory::class],
+                 ] as $key => $aliases) {
             foreach ($aliases as $alias) {
                 $this->alias($key, $alias);
             }

--- a/src/File/ConfigFile.php
+++ b/src/File/ConfigFile.php
@@ -17,7 +17,7 @@ class ConfigFile
 
     protected function convertStringCollectionsToArray()
     {
-        $collections = $this->config->get('collections');
+        $collections = value($this->config->get('collections'));
 
         if ($collections) {
             $this->config->put('collections', collect($collections)->flatMap(function ($value, $key) {

--- a/tests/RemoteCollectionsTest.php
+++ b/tests/RemoteCollectionsTest.php
@@ -657,4 +657,39 @@ class RemoteCollectionsTest extends TestCase
             $this->clean($files->getChild('build/test/test-1.html')->getContent()),
         );
     }
+
+    /**
+     * @test
+     */
+    public function collections_key_in_config_can_be_a_function_that_returns_a_list_of_collections()
+    {
+        $config = collect([
+            'collections' => fn () => [
+                'test' => [
+                    'extends' => '_layouts.master',
+                    'items' => function () {
+                        return collect([
+                            ['content' => 'item 1'],
+                            ['content' => 'item 2'],
+                        ]);
+                    },
+                ],
+            ],
+        ]);
+        $files = $this->setupSource([
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
+            ],
+        ]);
+        $this->buildSite($files, $config);
+
+        $this->assertEquals(
+            '<div><p>item 1</p></div>',
+            $this->clean($files->getChild('build/test/test-1.html')->getContent()),
+        );
+        $this->assertEquals(
+            '<div><p>item 2</p></div>',
+            $this->clean($files->getChild('build/test/test-2.html')->getContent()),
+        );
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -109,14 +109,12 @@ class TestCase extends BaseTestCase
         $this->app->consoleOutput->setup($verbosity = -1);
         $this->app->config = collect($this->app->config)->merge($config);
 
-        $collections = value($this->app->config->get('collections'));
-
-        if ($collections) {
+        if ($collections = value($this->app->config->get('collections'))) {
             $this->app->config->put('collections', collect($collections)->flatMap(function ($value, $key) {
                 return is_array($value) ? [$key => $value] : [$value => []];
             }));
         }
-        
+
         $this->app->buildPath = [
             'source' => $vfs->url() . '/source',
             'views' => $vfs->url() . $viewPath,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -108,6 +108,15 @@ class TestCase extends BaseTestCase
     {
         $this->app->consoleOutput->setup($verbosity = -1);
         $this->app->config = collect($this->app->config)->merge($config);
+
+        $collections = value($this->app->config->get('collections'));
+
+        if ($collections) {
+            $this->app->config->put('collections', collect($collections)->flatMap(function ($value, $key) {
+                return is_array($value) ? [$key => $value] : [$value => []];
+            }));
+        }
+        
         $this->app->buildPath = [
             'source' => $vfs->url() . '/source',
             'views' => $vfs->url() . $viewPath,


### PR DESCRIPTION
This PR addresses the issue https://github.com/tighten/jigsaw/issues/572

It allows us to set the collection using a function.

It means that now it is possible to get the collections and entries from an external API dynamically without having to expressly set the collections.