### PR TITLE
Add CommonMark markdown rendering option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "illuminate/filesystem": "^9.0",
         "illuminate/support": "^9.0",
         "illuminate/view": "^9.8",
+        "league/commonmark": "^2.4",
         "michelf/php-markdown": "^1.9",
         "mnapoli/front-yaml": "^1.5",
         "nunomaduro/collision": "^6.0",

--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -108,8 +108,8 @@ class InitCommand extends Command
 
     protected function initHasAlreadyBeenRun()
     {
-        return $this->files->exists($this->base . '/config.php') ||
-            $this->files->exists($this->base . '/source');
+        return $this->files->exists($this->base . '/config.php')
+            || $this->files->exists($this->base . '/source');
     }
 
     protected function askUserWhatToDoWithExistingSite()

--- a/src/Loaders/CollectionDataLoader.php
+++ b/src/Loaders/CollectionDataLoader.php
@@ -140,7 +140,7 @@ class CollectionDataLoader
         $links = $this->pathResolver->link(
             $data->path,
             new PageVariable($data),
-            Arr::get($collection->settings, 'transliterate', true)
+            Arr::get($collection->settings, 'transliterate', true),
         );
 
         return $links->count() ? new IterableObjectWithDefault($links) : null;

--- a/src/Parsers/CommonMarkParser.php
+++ b/src/Parsers/CommonMarkParser.php
@@ -4,7 +4,11 @@ namespace TightenCo\Jigsaw\Parsers;
 
 use Illuminate\Support\Arr;
 use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\Attributes\AttributesExtension;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\SmartPunct\SmartPunctExtension;
+use League\CommonMark\Extension\Strikethrough\StrikethroughExtension;
+use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\MarkdownConverter;
 
 class CommonMarkParser implements MarkdownParserContract
@@ -17,8 +21,12 @@ class CommonMarkParser implements MarkdownParserContract
 
         $environment->addExtension(new CommonMarkCoreExtension);
 
-        collect(Arr::get(app('config'), 'commonmark.extensions', []))
-            ->map(fn ($extension) => $environment->addExtension($extension));
+        collect(Arr::get(app('config'), 'commonmark.extensions', [
+            new AttributesExtension,
+            new SmartPunctExtension,
+            new StrikethroughExtension,
+            new TableExtension,
+        ]))->map(fn ($extension) => $environment->addExtension($extension));
 
         $this->converter = new MarkdownConverter($environment);
     }

--- a/src/Parsers/CommonMarkParser.php
+++ b/src/Parsers/CommonMarkParser.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace TightenCo\Jigsaw\Parsers;
+
+use Illuminate\Support\Arr;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\MarkdownConverter;
+
+class CommonMarkParser implements MarkdownParserContract
+{
+    private MarkdownConverter $converter;
+
+    public function __construct()
+    {
+        $environment = new Environment(Arr::get(app('config'), 'commonmark.config', []));
+
+        $environment->addExtension(new CommonMarkCoreExtension);
+
+        collect(Arr::get(app('config'), 'commonmark.extensions', []))
+            ->map(fn ($extension) => $environment->addExtension($extension));
+
+        $this->converter = new MarkdownConverter($environment);
+    }
+
+    public function parse(string $text)
+    {
+        return $this->converter->convert($text);
+    }
+}

--- a/src/Parsers/JigsawMarkdownParser.php
+++ b/src/Parsers/JigsawMarkdownParser.php
@@ -4,7 +4,7 @@ namespace TightenCo\Jigsaw\Parsers;
 
 use Michelf\MarkdownExtra;
 
-class JigsawMarkdownParser extends MarkdownExtra
+class JigsawMarkdownParser extends MarkdownExtra implements MarkdownParserContract
 {
     public function __construct()
     {

--- a/src/Parsers/MarkdownParser.php
+++ b/src/Parsers/MarkdownParser.php
@@ -2,15 +2,15 @@
 
 namespace TightenCo\Jigsaw\Parsers;
 
-use Mni\FrontYAML\Markdown\MarkdownParser as FrontYAMLMarkdownParser;
+use Mni\FrontYAML\Markdown\MarkdownParser as FrontYAMLMarkdownParserInterface;
 
-class MarkdownParser implements FrontYAMLMarkdownParser
+class MarkdownParser implements FrontYAMLMarkdownParserInterface
 {
     public $parser;
 
-    public function __construct(JigsawMarkdownParser $parser = null)
+    public function __construct(MarkdownParserContract $parser = null)
     {
-        $this->parser = $parser ?: new JigsawMarkdownParser();
+        $this->parser = $parser ?? new JigsawMarkdownParser;
     }
 
     public function __get($property)

--- a/src/Parsers/MarkdownParserContract.php
+++ b/src/Parsers/MarkdownParserContract.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TightenCo\Jigsaw\Parsers;
+
+interface MarkdownParserContract
+{
+    public function parse(string $text);
+}

--- a/src/PathResolvers/CollectionPathResolver.php
+++ b/src/PathResolvers/CollectionPathResolver.php
@@ -21,7 +21,7 @@ class CollectionPathResolver
         return collect($data->extends)->map(function ($bladeViewPath, $templateKey) use ($path, $data, $transliterate) {
             return $this->cleanOutputPath(
                 $this->getPath($path, $data, $this->getExtension($bladeViewPath), $templateKey),
-                $transliterate
+                $transliterate,
             );
         });
     }

--- a/src/Providers/MarkdownServiceProvider.php
+++ b/src/Providers/MarkdownServiceProvider.php
@@ -7,8 +7,11 @@ use Mni\FrontYAML\Markdown\MarkdownParser as FrontYAMLMarkdownParser;
 use Mni\FrontYAML\Parser;
 use Mni\FrontYAML\YAML\YAMLParser;
 use TightenCo\Jigsaw\Container;
+use TightenCo\Jigsaw\Parsers\CommonMarkParser;
 use TightenCo\Jigsaw\Parsers\FrontMatterParser;
+use TightenCo\Jigsaw\Parsers\JigsawMarkdownParser;
 use TightenCo\Jigsaw\Parsers\MarkdownParser;
+use TightenCo\Jigsaw\Parsers\MarkdownParserContract;
 use TightenCo\Jigsaw\Support\ServiceProvider;
 
 class MarkdownServiceProvider extends ServiceProvider
@@ -17,7 +20,11 @@ class MarkdownServiceProvider extends ServiceProvider
     {
         $this->app->bind(YAMLParser::class, SymfonyYAMLParser::class);
 
-        $this->app->singleton('markdownParser', fn (Container $app) => new MarkdownParser);
+        $this->app->bind(MarkdownParserContract::class, function (Container $app) {
+            return $app['config']->get('commonmark') ? new CommonMarkParser : new JigsawMarkdownParser;
+        });
+
+        $this->app->singleton('markdownParser', fn (Container $app) => new MarkdownParser($app[MarkdownParserContract::class]));
 
         // Make the FrontYAML package use our own Markdown parser internally
         $this->app->bind(FrontYAMLMarkdownParser::class, fn (Container $app) => $app['markdownParser']);

--- a/tests/CommonMarkTest.php
+++ b/tests/CommonMarkTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests;
+
+use League\CommonMark\Extension\Attributes\AttributesExtension;
+use TightenCo\Jigsaw\Parsers\MarkdownParserContract;
+
+class CommonMarkTest extends TestCase
+{
+    /** @test */
+    public function enable_commonmark_parser()
+    {
+        $files = $this->withContent('### Heading {.class}');
+
+        $this->buildSite($files, [
+            'commonmark' => true,
+        ]);
+
+        $this->assertSame(
+            '<div><h3>Heading {.class}</h3></div>',
+            $this->clean($files->getChild('build/test.html')->getContent()),
+        );
+    }
+
+    /** @test */
+    public function configure_commonmark_parser()
+    {
+        $files = $this->withContent('_Em_');
+
+        $this->buildSite($files, [
+            'commonmark' => [
+                'config' => [
+                    'commonmark' => [
+                        'enable_em' => false,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(
+            '<div><p>_Em_</p></div>',
+            $this->clean($files->getChild('build/test.html')->getContent()),
+        );
+    }
+
+    /** @test */
+    public function add_commonmark_extensions()
+    {
+        $files = $this->withContent('### Heading {.class}');
+
+        $this->buildSite($files, [
+            'commonmark' => [
+                'extensions' => [
+                    new AttributesExtension,
+                ],
+            ],
+        ]);
+
+        $this->assertSame(
+            '<div><h3 class="class">Heading</h3></div>',
+            $this->clean($files->getChild('build/test.html')->getContent()),
+        );
+    }
+
+    /** @test */
+    public function override_parser_with_custom_class()
+    {
+        $files = $this->withContent('### Heading {.class}');
+
+        $this->app->bind(MarkdownParserContract::class, function () {
+            return new class implements MarkdownParserContract
+            {
+                public function parse(string $text)
+                {
+                    return <<<EOT
+                        SYKE
+
+                        EOT;
+                }
+            };
+        });
+
+        $this->buildSite($files);
+
+        $this->assertSame(
+            '<div>SYKE</div>',
+            $this->clean($files->getChild('build/test.html')->getContent()),
+        );
+    }
+
+    private function withContent(string|array $content)
+    {
+        return $this->setupSource([
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
+            ],
+            ...(is_string($content)  ? [
+                'test.md' => $this->withFrontMatter($content),
+            ] : $content),
+        ]);
+    }
+
+    private function withFrontMatter(string $content): string
+    {
+        return <<<MD
+            ---
+            extends: _layouts.master
+            section: content
+            ---
+            {$content}
+            MD;
+    }
+}

--- a/tests/CommonMarkTest.php
+++ b/tests/CommonMarkTest.php
@@ -89,14 +89,12 @@ class CommonMarkTest extends TestCase
 
     private function withContent(string|array $content)
     {
-        return $this->setupSource([
+        return $this->setupSource(array_merge([
             '_layouts' => [
                 'master.blade.php' => "<div>@yield('content')</div>",
             ],
-            ...(is_string($content) ? [
-                'test.md' => $this->withFrontMatter($content),
-            ] : $content),
-        ]);
+            is_string($content) ? ['test.md' => $this->withFrontMatter($content)] : $content,
+        ]));
     }
 
     private function withFrontMatter(string $content): string

--- a/tests/CommonMarkTest.php
+++ b/tests/CommonMarkTest.php
@@ -68,8 +68,7 @@ class CommonMarkTest extends TestCase
         $files = $this->withContent('### Heading {.class}');
 
         $this->app->bind(MarkdownParserContract::class, function () {
-            return new class implements MarkdownParserContract
-            {
+            return new class implements MarkdownParserContract {
                 public function parse(string $text)
                 {
                     return <<<EOT
@@ -94,7 +93,7 @@ class CommonMarkTest extends TestCase
             '_layouts' => [
                 'master.blade.php' => "<div>@yield('content')</div>",
             ],
-            ...(is_string($content)  ? [
+            ...(is_string($content) ? [
                 'test.md' => $this->withFrontMatter($content),
             ] : $content),
         ]);

--- a/tests/CommonMarkTest.php
+++ b/tests/CommonMarkTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use League\CommonMark\Extension\Attributes\AttributesExtension;
 use League\CommonMark\Extension\DescriptionList\DescriptionListExtension;
 use TightenCo\Jigsaw\Parsers\MarkdownParserContract;
 

--- a/tests/CommonMarkTest.php
+++ b/tests/CommonMarkTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use League\CommonMark\Extension\Attributes\AttributesExtension;
+use League\CommonMark\Extension\DescriptionList\DescriptionListExtension;
 use TightenCo\Jigsaw\Parsers\MarkdownParserContract;
 
 class CommonMarkTest extends TestCase
@@ -17,7 +18,7 @@ class CommonMarkTest extends TestCase
         ]);
 
         $this->assertSame(
-            '<div><h3>Heading {.class}</h3></div>',
+            '<div><h3 class="class">Heading</h3></div>',
             $this->clean($files->getChild('build/test.html')->getContent()),
         );
     }
@@ -44,20 +45,26 @@ class CommonMarkTest extends TestCase
     }
 
     /** @test */
-    public function add_commonmark_extensions()
+    public function replace_commonmark_extensions()
     {
-        $files = $this->withContent('### Heading {.class}');
+        $files = $this->withContent(<<<MD
+            # Fruits {.class}
+
+            Apple
+            :   Pomaceous fruit of plants of the genus Malus in the family Rosaceae.
+            :   An American computer company.
+            MD);
 
         $this->buildSite($files, [
             'commonmark' => [
                 'extensions' => [
-                    new AttributesExtension,
+                    new DescriptionListExtension,
                 ],
             ],
         ]);
 
         $this->assertSame(
-            '<div><h3 class="class">Heading</h3></div>',
+            '<div><h1>Fruits {.class}</h1><dl><dt>Apple</dt><dd>Pomaceous fruit of plants of the genus Malus in the family Rosaceae.</dd><dd>An American computer company.</dd></dl></div>',
             $this->clean($files->getChild('build/test.html')->getContent()),
         );
     }


### PR DESCRIPTION
Adds the option to use `league/commonmark` to parse and render markdown. This can be enabled by setting the `commonmark` config to any value. To configure the CommonMark environment or add extensions, the `commonmark` config can be set to an array with `config` and `extensions` keys:

```php
// config.php

return [
    'commonmark' => [
        'config' => ['enable_em' => false],
        'extensions' => [new AttributesExtension],
    ],
];
```

The default configuration includes 4 extensions: attributes, smart punctuation, strikethrough, and tables. Extensions can easily be added or removed by overriding the `commonmark.extensions` config key.

Two other things:

- I'm not sure `MarkdownParserContract` is strictly necessary, and I wouldn't mind getting rid of it if we can, I just needed something to bind to.
- Changing `MarkdownParser` to take a `MarkdownParserContract` in its constructor instead of a `JigsawMarkdownParser` is not _technically_ a breaking change, right? We're widening that type, so all possible existing scenarios there will keep working, and the `$parser` property is not typed, so it could technically contain _anything_ right now, which is also still the case. If someone's reaching into the underlying parser to do anything funky that would almost definitely break if they enabled this new parser, but it's optional so I think that's fine.