### PR TITLE
Use real filesystem in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         php: ['8.0', '8.1', '8.2', '8.3']
         dependencies: [lowest, highest]
+        include:
+          - php: '8.3'
+            composer: --ignore-platform-req=php
     steps:
       - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
@@ -21,4 +24,5 @@ jobs:
       - uses: ramsey/composer-install@v2
         with:
           dependency-versions: ${{ matrix.dependencies }}
+          composer-options: ${{ matrix.composer }}
       - run: vendor/bin/phpunit --testdox --colors=always

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -41,6 +41,7 @@ return (new PhpCsFixer\Config)
             ],
         ],
         'phpdoc_var_annotation_correct_order' => true,
+        'single_line_empty_body' => true,
         'trailing_comma_in_multiline' => [
             'after_heredoc' => true,
             'elements' => ['arrays', 'arguments', 'parameters'],

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,7 @@
         "vlucas/phpdotenv": "^5.3.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.11",
-        "mikey179/vfsstream": "^1.6.11",
+        "friendsofphp/php-cs-fixer": "^3.17",
         "mockery/mockery": "^1.4",
         "phpunit/phpunit": "^9.3.3"
     },

--- a/src/Scaffold/InstallerCommandException.php
+++ b/src/Scaffold/InstallerCommandException.php
@@ -4,6 +4,4 @@ namespace TightenCo\Jigsaw\Scaffold;
 
 use Exception;
 
-class InstallerCommandException extends Exception
-{
-}
+class InstallerCommandException extends Exception {}

--- a/src/Support/ServiceProvider.php
+++ b/src/Support/ServiceProvider.php
@@ -8,8 +8,7 @@ abstract class ServiceProvider
 {
     public function __construct(
         protected Container $app,
-    ) {
-    }
+    ) {}
 
     public function register(): void
     {

--- a/tests/BladeComponentTest.php
+++ b/tests/BladeComponentTest.php
@@ -4,7 +4,6 @@ namespace Tests;
 
 use Illuminate\Container\Container;
 use Illuminate\View\Component;
-use org\bovigo\vfs\vfsStream;
 
 class BladeComponentTest extends TestCase
 {
@@ -33,15 +32,13 @@ class BladeComponentTest extends TestCase
 
         $this->buildSite($files, []);
 
-        $built = $files->getChild('build/page.html')->getContent();
-
-        $this->assertEquals(
-            "<div>\n" .
-            "<h3>This is the component</h3>\n" .
-            "<h4>Named title slot: Title test</h4>\n" .
-            "<h1>Default content</h1>\n" .
-            '</div>',
-            $built,
+        $this->assertOutputFile('build/page.html', <<<HTML
+            <div>
+            <h3>This is the component</h3>
+            <h4>Named title slot: Title test</h4>
+            <h1>Default content</h1>
+            </div>
+            HTML,
         );
     }
 
@@ -74,12 +71,10 @@ class BladeComponentTest extends TestCase
     {
         $this->app['bladeCompiler']->component('alert', AlertComponent::class);
 
-        $files = vfsStream::setup('virtual', null, [
-            'source' => [
-                'page.blade.php' => '<h1>Hello</h1><x-alert type="error" message="The message"/>',
-                '_components' => [
-                    'alert.blade.php' => '<div class="alert alert-{{ $type }}">{{ $message }}</div>',
-                ],
+        $files = $this->setupSource([
+            'page.blade.php' => '<h1>Hello</h1><x-alert type="error" message="The message"/>',
+            '_components' => [
+                'alert.blade.php' => '<div class="alert alert-{{ $type }}">{{ $message }}</div>',
             ],
         ]);
 
@@ -100,10 +95,8 @@ class BladeComponentTest extends TestCase
     {
         $this->app['bladeCompiler']->component('inline', InlineAlertComponent::class);
 
-        $files = vfsStream::setup('virtual', null, [
-            'source' => [
-                'page.blade.php' => '<h1>Hello</h1><x-inline type="error" message="The message"/>',
-            ],
+        $files = $this->setupSource([
+            'page.blade.php' => '<h1>Hello</h1><x-inline type="error" message="The message"/>',
         ]);
 
         $this->buildSite($files, []);
@@ -123,10 +116,8 @@ class BladeComponentTest extends TestCase
     {
         class_alias('Tests\InlineAlertComponent', 'Components\InlineClassComponent');
 
-        $files = vfsStream::setup('virtual', null, [
-            'source' => [
-                'page.blade.php' => '<h1>Hello</h1><x-inline-class-component type="error" message="The message"/>',
-            ],
+        $files = $this->setupSource([
+            'page.blade.php' => '<h1>Hello</h1><x-inline-class-component type="error" message="The message"/>',
         ]);
 
         $this->buildSite($files, []);
@@ -146,12 +137,10 @@ class BladeComponentTest extends TestCase
     {
         class_alias('Tests\\AlertComponent', 'Components\\ClassComponent');
 
-        $files = vfsStream::setup('virtual', null, [
-            'source' => [
-                'page.blade.php' => '<h1>Hello</h1><x-class-component type="error" message="The message"/>',
-                '_components' => [
-                    'alert.blade.php' => '<div class="alert alert-{{ $type }}">{{ $message }}</div>',
-                ],
+        $files = $this->setupSource([
+            'page.blade.php' => '<h1>Hello</h1><x-class-component type="error" message="The message"/>',
+            '_components' => [
+                'alert.blade.php' => '<div class="alert alert-{{ $type }}">{{ $message }}</div>',
             ],
         ]);
 

--- a/tests/CollectionItemTest.php
+++ b/tests/CollectionItemTest.php
@@ -76,8 +76,8 @@ class CollectionItemTest extends TestCase
         $this->assertNull($jigsaw->getSiteData()->collection->filtered);
         $this->assertNotNull($jigsaw->getSiteData()->collection->item);
 
-        $this->assertNull($files->getChild('build/collection/filtered.html'));
-        $this->assertNotNull($files->getChild('build/collection/item.html'));
+        $this->assertFileMissing($this->tmpPath('build/collection/filtered.html'));
+        $this->assertFileExists($this->tmpPath('build/collection/item.html'));
     }
 
     /**
@@ -237,7 +237,7 @@ class CollectionItemTest extends TestCase
         $this->buildSite($files, $config, $pretty = true);
 
         $this->assertEquals(
-            'vfs://virtual/source/_collection',
+            "{$this->tmp}/source/_collection",
             $this->clean($files->getChild('build/collection/page/index.html')->getContent()),
         );
     }

--- a/tests/CustomCommandTest.php
+++ b/tests/CustomCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use org\bovigo\vfs\vfsStream;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use TightenCo\Jigsaw\Console\Command;
@@ -14,7 +13,7 @@ class CustomCommandTest extends TestCase
      */
     public function custom_command_with_no_arguments()
     {
-        $vfs = vfsStream::setup('virtual', null, []);
+        $this->createSource([]);
         $command = $this->app->make(CustomCommand::class);
         $command->setApplication(new Application());
 

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -387,7 +387,7 @@ class EventsTest extends TestCase
             $jigsaw->setSourcePath("{$this->tmp}/new_source");
             $result = $jigsaw->getSourcePath();
         });
-        $this->buildSite(new class {});
+        $this->buildSite();
 
         $this->assertEquals("{$this->tmp}/source", $original);
         $this->assertEquals("{$this->tmp}/new_source", $result);

--- a/tests/FilesystemTest.php
+++ b/tests/FilesystemTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use org\bovigo\vfs\vfsStream;
 use TightenCo\Jigsaw\File\Filesystem;
 
 class FilesystemTest extends TestCase
@@ -31,7 +30,7 @@ class FilesystemTest extends TestCase
         $filesystem = $this->app->make(Filesystem::class);
         $vfs = $this->setupFiles();
 
-        $files = $filesystem->filesAndDirectories($vfs->url());
+        $files = $filesystem->filesAndDirectories($this->tmp);
 
         $this->assertCount(11, $files);
     }
@@ -41,7 +40,7 @@ class FilesystemTest extends TestCase
      */
     public function DS_Store_is_always_ignored_when_retrieving_all_files_and_directories()
     {
-        $vfs = vfsStream::setup('virtual', null, [
+        $this->createSource([
             'test-file.md' => '',
             '.gitignore' => '',
             '.DS_Store' => '',
@@ -49,7 +48,7 @@ class FilesystemTest extends TestCase
 
         $files = collect(
             $this->app->make(Filesystem::class)
-            ->filesAndDirectories($vfs->url()),
+            ->filesAndDirectories($this->tmp),
         )->map(function ($file) {
             return $file->getRelativePathName();
         });
@@ -203,7 +202,7 @@ class FilesystemTest extends TestCase
         $filesystem = $this->app->make(Filesystem::class);
         $vfs = $this->setupFiles();
 
-        $files = $filesystem->filesAndDirectories($vfs->url(), 'file-1.md');
+        $files = $filesystem->filesAndDirectories($this->tmp, 'file-1.md');
 
         $this->assertCount(1, $files);
         $this->assertEquals('file-1.md', $files[0]->getFileName());
@@ -220,8 +219,8 @@ class FilesystemTest extends TestCase
         ]);
 
         $this->assertCount(2, $files);
-        $this->assertEquals('file-1.md', $files[0]);
-        $this->assertEquals('file-2.md', $files[1]);
+        $this->assertEquals('file-2.md', $files[0]);
+        $this->assertEquals('file-1.md', $files[1]);
     }
 
     /**
@@ -234,8 +233,8 @@ class FilesystemTest extends TestCase
         ]);
 
         $this->assertCount(2, $files);
-        $this->assertEquals('file-1.md', $files[0]);
-        $this->assertEquals('file-2.md', $files[1]);
+        $this->assertEquals('file-2.md', $files[0]);
+        $this->assertEquals('file-1.md', $files[1]);
     }
 
     /**
@@ -249,14 +248,16 @@ class FilesystemTest extends TestCase
 
         $this->assertCount(7, $files);
         $this->assertEquals('directory', $files[0]);
-        $this->assertEquals($this->fixDirectorySlashes('directory/nested-file-1.md'), $files[1]);
+        $this->assertEquals($this->fixDirectorySlashes('directory/nested-file-1.md'), $files[2]);
     }
 
     protected function getFilesMatching($match)
     {
+        $this->setupFiles();
+
         return collect(
             $this->app->make(Filesystem::class)
-            ->filesAndDirectories($this->setupFiles()->url(), $match),
+            ->filesAndDirectories($this->tmp, $match),
         )->map(function ($file) {
             return $file->getRelativePathName();
         });
@@ -264,9 +265,11 @@ class FilesystemTest extends TestCase
 
     protected function getFilesExcept($ignore)
     {
+        $this->setupFiles();
+
         return collect(
             $this->app->make(Filesystem::class)
-            ->filesAndDirectories($this->setupFiles()->url(), null, $ignore),
+            ->filesAndDirectories($this->tmp, null, $ignore),
         )->map(function ($file) {
             return $file->getRelativePathName();
         });
@@ -274,6 +277,6 @@ class FilesystemTest extends TestCase
 
     protected function setupFiles()
     {
-        return vfsStream::setup('virtual', null, self::TEST_FILES);
+        $this->createSource(self::TEST_FILES);
     }
 }

--- a/tests/FilesystemTest.php
+++ b/tests/FilesystemTest.php
@@ -218,9 +218,7 @@ class FilesystemTest extends TestCase
             'file-2.md',
         ]);
 
-        $this->assertCount(2, $files);
-        $this->assertEquals('file-2.md', $files[0]);
-        $this->assertEquals('file-1.md', $files[1]);
+        $this->assertEqualsCanonicalizing(['file-1.md', 'file-2.md'], $files->all());
     }
 
     /**
@@ -232,9 +230,7 @@ class FilesystemTest extends TestCase
             'file-*.md',
         ]);
 
-        $this->assertCount(2, $files);
-        $this->assertEquals('file-2.md', $files[0]);
-        $this->assertEquals('file-1.md', $files[1]);
+        $this->assertEqualsCanonicalizing(['file-1.md', 'file-2.md'], $files->all());
     }
 
     /**
@@ -247,8 +243,8 @@ class FilesystemTest extends TestCase
         ]);
 
         $this->assertCount(7, $files);
-        $this->assertEquals('directory', $files[0]);
-        $this->assertEquals($this->fixDirectorySlashes('directory/nested-file-1.md'), $files[2]);
+        $this->assertEquals('directory', $files->sort()[0]);
+        $this->assertEquals($this->fixDirectorySlashes('directory/nested-file-1.md'), $files->sort()[2]);
     }
 
     protected function getFilesMatching($match)

--- a/tests/FilesystemTest.php
+++ b/tests/FilesystemTest.php
@@ -242,9 +242,15 @@ class FilesystemTest extends TestCase
             'directory',
         ]);
 
-        $this->assertCount(7, $files);
-        $this->assertEquals('directory', $files->sort()[0]);
-        $this->assertEquals($this->fixDirectorySlashes('directory/nested-file-1.md'), $files->sort()[2]);
+        $this->assertEqualsCanonicalizing([
+            'directory',
+            $this->fixDirectorySlashes('directory/nested-directory'),
+            $this->fixDirectorySlashes('directory/nested-directory/double-nested-file-1.md'),
+            $this->fixDirectorySlashes('directory/nested-directory/double-nested-file-2.md'),
+            $this->fixDirectorySlashes('directory/nested-empty-directory'),
+            $this->fixDirectorySlashes('directory/nested-file-1.md'),
+            $this->fixDirectorySlashes('directory/nested-file-2.md'),
+        ], $files->all());
     }
 
     protected function getFilesMatching($match)

--- a/tests/Haiku.php
+++ b/tests/Haiku.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+trait Haiku
+{
+    protected static array $adjectives = ['aged', 'amiable', 'ancient', 'balmy', 'beautiful', 'billowing', 'blessed', 'bold', 'bountiful', 'breezy', 'bubbling', 'calm', 'celestial', 'clean', 'cold', 'colorful', 'colossal', 'crimson', 'curved', 'damp', 'deep', 'divine', 'exquisite', 'fancy', 'fathomless', 'floral', 'fragrant', 'frosty', 'gentle', 'gorgeous', 'graceful', 'harmonious', 'hidden', 'hollow', 'holy', 'icy', 'indigo', 'jubilant', 'limitless', 'lingering', 'lively', 'mellow', 'merciful', 'mirthful', 'misty', 'moonlit', 'mythic', 'quaint', 'polished', 'precious', 'purple', 'red', 'resilient', 'royal', 'scenic', 'silent', 'snowy', 'solitary', 'sparkling', 'stunning', 'summer', 'smooth', 'tall', 'twilight', 'unwavering', 'warm', 'wandering', 'weathered', 'whispering', 'wispy', 'zealous'];
+
+    protected static array $nouns = ['abyss', 'atoll', 'aurora', 'autumn', 'badlands', 'beach', 'breeze', 'briars', 'butterfly', 'brook', 'canopy', 'canyon', 'cavern', 'chasm', 'cliff', 'cloud', 'cove', 'crater', 'creek', 'darkness', 'dawn', 'desert', 'dew', 'dream', 'dusk', 'dust', 'farm', 'feather', 'fern', 'field', 'fire', 'firefly', 'flowers', 'fog', 'forest', 'frost', 'galaxy', 'garden', 'geyser', 'glade', 'grass', 'grove', 'hamlet', 'haze', 'hill', 'hurricane', 'iceberg', 'king', 'lagoon', 'lake', 'leaf', 'meadow', 'mist', 'moon', 'morning', 'moss', 'mountain', 'night', 'oasis', 'ocean', 'peak', 'pebble', 'pine', 'plateau', 'pond', 'rain', 'reef', 'reserve', 'resonance', 'river', 'sanctuary', 'sands', 'sea', 'shadow', 'shelter', 'silence', 'snowflake', 'sound', 'spring', 'star', 'storm', 'stream', 'summer', 'summit', 'sun', 'sunrise', 'sunset', 'surf', 'thunder', 'temple', 'truth', 'tundra', 'valley', 'waterfall', 'wave', 'wildflower', 'willow', 'winds', 'winter'];
+
+    public static function haiku()
+    {
+        return implode('-', [Arr::random(static::$adjectives), Arr::random(static::$nouns), Str::random(4)]);
+    }
+}

--- a/tests/InitCommandTest.php
+++ b/tests/InitCommandTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use Mockery;
-use org\bovigo\vfs\vfsStream;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use TightenCo\Jigsaw\Console\InitCommand;
@@ -24,10 +23,10 @@ class InitCommandTest extends TestCase
             ->andReturn($basic_scaffold);
         $this->app->instance(BasicScaffoldBuilder::class, $basic_scaffold);
 
-        $vfs = vfsStream::setup('virtual', null, []);
+        $this->createSource([]);
         $command = $this->app->make(InitCommand::class);
         $command->setApplication(new Application());
-        $command->setBase($vfs->url());
+        $command->setBase($this->tmp);
 
         $console = new CommandTester($command);
         $console->execute([]);
@@ -48,10 +47,10 @@ class InitCommandTest extends TestCase
             ->andReturn($preset_scaffold);
         $this->app->instance(PresetScaffoldBuilder::class, $preset_scaffold);
 
-        $vfs = vfsStream::setup('virtual', null, []);
+        $this->createSource([]);
         $command = $this->app->make(InitCommand::class);
         $command->setApplication(new Application());
-        $command->setBase($vfs->url());
+        $command->setBase($this->tmp);
 
         $console = new CommandTester($command);
         $console->execute(['preset' => 'blog']);
@@ -79,10 +78,10 @@ class InitCommandTest extends TestCase
      */
     public function init_command_displays_warning_if_source_directory_exists()
     {
-        $vfs = vfsStream::setup('virtual', null, ['source' => []]);
+        $this->createSource(['source' => []]);
         $command = $this->app->make(InitCommand::class);
         $command->setApplication(new Application());
-        $command->setBase($vfs->url());
+        $command->setBase($this->tmp);
 
         $console = new CommandTester($command);
         $console->setInputs(['c']);
@@ -96,10 +95,10 @@ class InitCommandTest extends TestCase
      */
     public function init_command_displays_warning_if_config_dot_php_exists()
     {
-        $vfs = vfsStream::setup('virtual', null, ['config.php' => '']);
+        $this->createSource(['config.php' => '']);
         $command = $this->app->make(InitCommand::class);
         $command->setApplication(new Application());
-        $command->setBase($vfs->url());
+        $command->setBase($this->tmp);
 
         $console = new CommandTester($command);
         $console->setInputs(['c']);
@@ -120,10 +119,10 @@ class InitCommandTest extends TestCase
             ->andReturn($basic_scaffold);
         $this->app->instance(BasicScaffoldBuilder::class, $basic_scaffold);
 
-        $vfs = vfsStream::setup('virtual', null, ['config.php' => '']);
+        $this->createSource(['config.php' => '']);
         $command = $this->app->make(InitCommand::class);
         $command->setApplication(new Application());
-        $command->setBase($vfs->url());
+        $command->setBase($this->tmp);
 
         $console = new CommandTester($command);
         $console->setInputs(['c']);
@@ -146,10 +145,10 @@ class InitCommandTest extends TestCase
             ->andReturn($basic_scaffold);
         $this->app->instance(BasicScaffoldBuilder::class, $basic_scaffold);
 
-        $vfs = vfsStream::setup('virtual', null, ['config.php' => '']);
+        $this->createSource(['config.php' => '']);
         $command = $this->app->make(InitCommand::class);
         $command->setApplication(new Application());
-        $command->setBase($vfs->url());
+        $command->setBase($this->tmp);
 
         $console = new CommandTester($command);
         $console->setInputs(['a']);
@@ -171,10 +170,10 @@ class InitCommandTest extends TestCase
             ->andReturn($basic_scaffold);
         $this->app->instance(BasicScaffoldBuilder::class, $basic_scaffold);
 
-        $vfs = vfsStream::setup('virtual', null, ['config.php' => '']);
+        $this->createSource(['config.php' => '']);
         $command = $this->app->make(InitCommand::class);
         $command->setApplication(new Application());
-        $command->setBase($vfs->url());
+        $command->setBase($this->tmp);
 
         $console = new CommandTester($command);
         $console->setInputs(['a']);
@@ -196,10 +195,10 @@ class InitCommandTest extends TestCase
             ->andReturn($basic_scaffold);
         $this->app->instance(BasicScaffoldBuilder::class, $basic_scaffold);
 
-        $vfs = vfsStream::setup('virtual', null, ['config.php' => '']);
+        $this->createSource(['config.php' => '']);
         $command = $this->app->make(InitCommand::class);
         $command->setApplication(new Application());
-        $command->setBase($vfs->url());
+        $command->setBase($this->tmp);
 
         $console = new CommandTester($command);
         $console->setInputs(['d', 'y']);
@@ -221,10 +220,10 @@ class InitCommandTest extends TestCase
             ->andReturn($basic_scaffold);
         $this->app->instance(BasicScaffoldBuilder::class, $basic_scaffold);
 
-        $vfs = vfsStream::setup('virtual', null, ['config.php' => '']);
+        $this->createSource(['config.php' => '']);
         $command = $this->app->make(InitCommand::class);
         $command->setApplication(new Application());
-        $command->setBase($vfs->url());
+        $command->setBase($this->tmp);
 
         $console = new CommandTester($command);
         $console->setInputs(['d', 'y']);

--- a/tests/IterableObjectTest.php
+++ b/tests/IterableObjectTest.php
@@ -176,6 +176,4 @@ class IterableObjectTest extends TestCase
     }
 }
 
-class ExtendsIterableObject extends IterableObject
-{
-}
+class ExtendsIterableObject extends IterableObject {}

--- a/tests/PageDataBindingTest.php
+++ b/tests/PageDataBindingTest.php
@@ -5,7 +5,6 @@ namespace Tests;
 use Illuminate\Container\Container;
 use Illuminate\Support\Str;
 use Illuminate\View\Component;
-use org\bovigo\vfs\vfsStream;
 use TightenCo\Jigsaw\PageData;
 
 class PageDataBindingTest extends TestCase
@@ -19,10 +18,8 @@ class PageDataBindingTest extends TestCase
             $this->assertTrue($component->page instanceof PageData);
         });
 
-        $files = vfsStream::setup('virtual', null, [
-            'source' => [
-                'page.blade.php' => '<x-page-header/>',
-            ],
+        $files = $this->setupSource([
+            'page.blade.php' => '<x-page-header/>',
         ]);
 
         $this->buildSite($files, []);

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -393,8 +393,8 @@ class PaginationTest extends TestCase
         $this->assertSame('post1post2', $this->clean($files->getChild('build/blog/index.html')->getContent()));
         $this->assertSame('post3post4', $this->clean($files->getChild('build/blog/page/2/index.html')->getContent()));
         $this->assertSame('post5', $this->clean($files->getChild('build/blog/page/3/index.html')->getContent()));
-        $this->assertNull($files->getChild('build/blog/2/index.html'));
-        $this->assertNull($files->getChild('build/blog/3/index.html'));
+        $this->assertFileMissing($this->tmpPath('build/blog/2/index.html'));
+        $this->assertFileMissing($this->tmpPath('build/blog/3/index.html'));
     }
 
     /** @test */
@@ -429,7 +429,7 @@ class PaginationTest extends TestCase
         $this->assertSame('post1post2', $this->clean($files->getChild('build/blog/index.html')->getContent()));
         $this->assertSame('post3post4', $this->clean($files->getChild('build/blog/page/2/index.html')->getContent()));
         $this->assertSame('post5', $this->clean($files->getChild('build/blog/page/3/index.html')->getContent()));
-        $this->assertNull($files->getChild('build/blog/2/index.html'));
-        $this->assertNull($files->getChild('build/blog/3/index.html'));
+        $this->assertFileMissing($this->tmpPath('build/blog/2/index.html'));
+        $this->assertFileMissing($this->tmpPath('build/blog/3/index.html'));
     }
 }

--- a/tests/RemoteCollectionsTest.php
+++ b/tests/RemoteCollectionsTest.php
@@ -194,7 +194,7 @@ class RemoteCollectionsTest extends TestCase
         ]);
         $this->buildSite($files, $config);
 
-        $this->assertNull($files->getChild('source/_test/_tmp'));
+        $this->assertFileMissing($this->tmpPath('source/_test/_tmp'));
     }
 
     /**
@@ -221,7 +221,7 @@ class RemoteCollectionsTest extends TestCase
         ]);
         $this->buildSite($files, $config);
 
-        $this->assertNull($files->getChild('source/_test'));
+        $this->assertFileMissing($this->tmpPath('source/_test'));
     }
 
     /**

--- a/tests/SiteBuilderTest.php
+++ b/tests/SiteBuilderTest.php
@@ -142,7 +142,7 @@ class SiteBuilderTest extends TestCase
         ]);
         $jigsaw = $this->buildSite($files, [], $pretty = true);
 
-        $this->assertEquals(
+        $this->assertEqualsCanonicalizing(
             [
                 '/page1',
                 '/nested/page2',

--- a/tests/SiteBuilderTest.php
+++ b/tests/SiteBuilderTest.php
@@ -18,7 +18,7 @@ class SiteBuilderTest extends TestCase
             ],
         ]);
 
-        $this->buildSite(new class {});
+        $this->buildSite();
 
         $this->assertCount(1, app('files')->filesAndDirectories($this->tmpPath('build')));
     }
@@ -37,7 +37,7 @@ class SiteBuilderTest extends TestCase
             ],
         ]);
 
-        $this->buildSite(new class {});
+        $this->buildSite();
 
         $this->assertCount(1, app('files')->filesAndDirectories($this->tmpPath('build')));
         $this->assertOutputFile('build/test.html', 'New file');

--- a/tests/SiteBuilderTest.php
+++ b/tests/SiteBuilderTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests;
 
-use org\bovigo\vfs\vfsStream;
-
 class SiteBuilderTest extends TestCase
 {
     /**
@@ -11,7 +9,7 @@ class SiteBuilderTest extends TestCase
      */
     public function destination_directory_is_deleted_when_building_site()
     {
-        $files = vfsStream::setup('virtual', null, [
+        $this->createSource([
             'build' => [
                 'old.blade.php' => 'Old file',
             ],
@@ -20,9 +18,9 @@ class SiteBuilderTest extends TestCase
             ],
         ]);
 
-        $this->buildSite($files);
+        $this->buildSite(new class {});
 
-        $this->assertCount(1, $files->getChild('build')->getChildren());
+        $this->assertCount(1, app('files')->filesAndDirectories($this->tmpPath('build')));
     }
 
     /**
@@ -30,7 +28,7 @@ class SiteBuilderTest extends TestCase
      */
     public function existing_files_in_destination_directory_are_replaced_when_building_site()
     {
-        $files = vfsStream::setup('virtual', null, [
+        $this->createSource([
             'build' => [
                 'test.blade.php' => 'Old file',
             ],
@@ -39,10 +37,10 @@ class SiteBuilderTest extends TestCase
             ],
         ]);
 
-        $this->buildSite($files);
+        $this->buildSite(new class {});
 
-        $this->assertCount(1, $files->getChild('build')->getChildren());
-        $this->assertEquals('New file', $files->getChild('build')->getChild('build/test.html')->getContent());
+        $this->assertCount(1, app('files')->filesAndDirectories($this->tmpPath('build')));
+        $this->assertOutputFile('build/test.html', 'New file');
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -103,6 +103,9 @@ class TestCase extends PHPUnit
         return "{$this->tmp}/{$path}";
     }
 
+    /**
+     * @deprecated Use createSource instead.
+     */
     protected function setupSource($source = [])
     {
         $this->createSource(['source' => $source]);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -160,7 +160,7 @@ class TestCase extends PHPUnit
         $create($this->tmp, $files, $create);
     }
 
-    protected function buildSiteData($vfs, $config = [])
+    protected function buildSiteData($vfs = null, $config = [])
     {
         $this->app->consoleOutput->setup($verbosity = -1);
         $loader = $this->app->make(DataLoader::class);
@@ -170,7 +170,7 @@ class TestCase extends PHPUnit
         return $siteData->addCollectionData($collectionData);
     }
 
-    public function buildSite($vfs, $config = [], $pretty = false, $viewPath = '/source')
+    public function buildSite($vfs = null, $config = [], $pretty = false, $viewPath = '/source')
     {
         $this->app->consoleOutput->setup($verbosity = -1);
         $this->app->config = collect($this->app->config)->merge($config);

--- a/tests/TestCaseTest.php
+++ b/tests/TestCaseTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests;
+
+class TestCaseTest extends TestCase
+{
+    /** @test */
+    public function create_test_file_structure_from_nested_array()
+    {
+        $this->createSource([
+            'content' => [
+                'pages' => [],
+                'posts' => [
+                    'unique.md' => 'New York',
+                    '2020' => [
+                        'stay.md' => 'Home',
+                    ],
+                ],
+                'index.md' => 'Welcome',
+            ],
+            'public' => [],
+            'resources' => [
+                'js' => [
+                    'main.js' => 'console.log("Look ma, no file system!");',
+                ],
+            ],
+        ]);
+
+        $this->assertDirectoryExists($this->tmpPath('content'));
+        $this->assertDirectoryExists($this->tmpPath('content/pages'));
+        $this->assertEmpty(app('files')->files($this->tmpPath('content/pages')));
+        $this->assertDirectoryExists($this->tmpPath('content/posts'));
+        $this->assertStringEqualsFile($this->tmpPath('content/posts/unique.md'), 'New York');
+        $this->assertDirectoryExists($this->tmpPath('content/posts/2020/'));
+        $this->assertStringEqualsFile($this->tmpPath('content/posts/2020/stay.md'), 'Home');
+        $this->assertStringEqualsFile($this->tmpPath('content/index.md'), 'Welcome');
+        $this->assertDirectoryExists($this->tmpPath('public'));
+        $this->assertEmpty(app('files')->files($this->tmpPath('public')));
+        $this->assertDirectoryExists($this->tmpPath('resources'));
+        $this->assertDirectoryExists($this->tmpPath('resources/js'));
+        $this->assertStringEqualsFile($this->tmpPath('resources/js/main.js'), 'console.log("Look ma, no file system!");');
+    }
+
+    /** @test */
+    public function create_test_files_with_multiple_extensions()
+    {
+        $this->createSource([
+            'content' => [
+                'pages' => [
+                    'one.blade.md' => 'Two',
+                    'one' => [
+                        'two.blade.php' => 'Three',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertDirectoryExists($this->tmpPath('content'));
+        $this->assertDirectoryExists($this->tmpPath('content/pages'));
+        $this->assertStringEqualsFile($this->tmpPath('content/pages/one.blade.md'), 'Two');
+        $this->assertDirectoryExists($this->tmpPath('content/pages/one'));
+        $this->assertStringEqualsFile($this->tmpPath('content/pages/one/two.blade.php'), 'Three');
+    }
+}

--- a/tests/ViewPathTest.php
+++ b/tests/ViewPathTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-
 class ViewPathTest extends TestCase
 {
     /** @test */

--- a/tests/ViewPathTest.php
+++ b/tests/ViewPathTest.php
@@ -25,7 +25,7 @@ class ViewPathTest extends TestCase
             ],
         ]);
 
-        $this->buildSite(new class {}, [], false, '/views');
+        $this->buildSite(null, [], false, '/views');
 
         $this->assertOutputFile('build/page.html', <<<HTML
             <body>

--- a/tests/ViewPathTest.php
+++ b/tests/ViewPathTest.php
@@ -2,14 +2,13 @@
 
 namespace Tests;
 
-use org\bovigo\vfs\vfsStream;
 
 class ViewPathTest extends TestCase
 {
     /** @test */
     public function can_load_views_from_custom_path()
     {
-        $files = vfsStream::setup('virtual', null, [
+        $this->createSource([
             'source' => [
                 'page.md' => <<<MD
                 ---
@@ -27,14 +26,13 @@ class ViewPathTest extends TestCase
             ],
         ]);
 
-        $this->buildSite($files, [], false, '/views');
+        $this->buildSite(new class {}, [], false, '/views');
 
-        $this->assertSame(<<<HTML
+        $this->assertOutputFile('build/page.html', <<<HTML
             <body>
                 <h1>Hello world!</h1>
             </body>
             HTML,
-            $files->getChild('build/page.html')->getContent(),
         );
     }
 }

--- a/tests/fixtures/tmp/.gitignore
+++ b/tests/fixtures/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This PR updates all tests to use the real filesystem instead of a virtual one, and uninstalls `mikey179/vfsstream`. This brings the test environment/behaviour closer to how Jigsaw actually runs in real environments, and it makes debugging and inspecting failing tests significantly easier.

Kind of similarly to Laravel's `Storage::fake()` (which only cleans up previous tests' files at the beginning of the next test run), this PR only cleans up test files if all tests passed, so if anything goes wrong the test files are preserved and we can review them.

I also added some cleaner setup helper methods, but to keep this PR from getting too noisy I didn't replace the old ones everywhere yet.

The performance hit here (I _think_ using the real filesystem is slower) is negligible.