### PR TITLE
fixing PHPUnit BC break on base TestCase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor/
+.idea/
 .php-cs-fixer.cache
 .phpunit.result.cache
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -18,30 +18,31 @@
         }
     ],
     "require": {
-        "php": "^8.0.2 <8.4",
-        "illuminate/collections": "^9.0",
-        "illuminate/console": "^9.21.1",
-        "illuminate/container": "^9.0",
-        "illuminate/filesystem": "^9.0",
-        "illuminate/support": "^9.0",
-        "illuminate/view": "^9.8",
+        "php": "^8.3",
+        "illuminate/collections": "^11.0.7",
+        "illuminate/console": "^11.0.7",
+        "illuminate/container": "^11.0.7",
+        "illuminate/filesystem": "^11.0.7",
+        "illuminate/support": "^11.0.7",
+        "illuminate/view": "^11.0.7",
         "league/commonmark": "^2.4",
-        "michelf/php-markdown": "^1.9",
-        "mnapoli/front-yaml": "^1.5",
-        "nunomaduro/collision": "^6.0",
-        "spatie/laravel-ignition": "^1.6",
-        "symfony/console": "^5.4 || ^6.0",
-        "symfony/error-handler": "^5.0 || ^6.0",
-        "symfony/finder": "^5.3.7 || ^6.0",
-        "symfony/process": "^5.0 || ^6.0",
-        "symfony/var-dumper": "^5.0 || ^6.0",
-        "symfony/yaml": "^5.0 || ^6.0",
-        "vlucas/phpdotenv": "^5.3.1"
+        "michelf/php-markdown": "^2.0",
+        "mnapoli/front-yaml": "^2.0",
+        "nunomaduro/collision": "^8.1",
+        "spatie/laravel-ignition": "^2.4",
+        "symfony/console": "^6.0 || ^7.0",
+        "symfony/error-handler": "^6.0 || ^7.0",
+        "symfony/finder": "^6.0 || ^7.0",
+        "symfony/process": "^6.0 || ^7.0",
+        "symfony/var-dumper": "^6.0 || ^7.0",
+        "symfony/yaml": "^6.0 || ^7.0",
+        "vlucas/phpdotenv": "^5.6",
+        "laravel/prompts": "^0.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.17",
-        "mockery/mockery": "^1.4",
-        "phpunit/phpunit": "^9.3.3"
+        "friendsofphp/php-cs-fixer": "^3.51",
+        "mockery/mockery": "^1.6",
+        "phpunit/phpunit": "^11.0.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/Bootstrap/HandleExceptions.php
+++ b/src/Bootstrap/HandleExceptions.php
@@ -67,7 +67,7 @@ class HandleExceptions
     /**
      * Handle a deprecation.
      *
-     * @throws \TightenCo\Jigsaw\Exceptions\DeprecationException
+     * @throws DeprecationException
      */
     private function handleDeprecation(Throwable $e): void
     {
@@ -82,7 +82,7 @@ class HandleExceptions
             //
         }
 
-        static::$app->make(ExceptionHandler::class)->renderForConsole(new ConsoleOutput, $e);
+        static::$app->make(ExceptionHandler::class)->renderForConsole(new ConsoleOutput(), $e);
     }
 
     /**
@@ -102,7 +102,7 @@ class HandleExceptions
             //
         }
 
-        static::$app->make(ExceptionHandler::class)->renderForConsole(new ConsoleOutput, $e);
+        static::$app->make(ExceptionHandler::class)->renderForConsole(new ConsoleOutput(), $e);
     }
 
     /**

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -12,7 +12,7 @@ abstract class Command extends SymfonyCommand
     protected OutputInterface $output;
     protected $console;
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int 
     {
         $this->input = $input;
         $this->output = $output;

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -8,8 +8,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class Command extends SymfonyCommand
 {
-    protected $input;
-    protected $output;
+    protected InputInterface  $input;
+    protected OutputInterface $output;
     protected $console;
 
     public function execute(InputInterface $input, OutputInterface $output)

--- a/src/Container.php
+++ b/src/Container.php
@@ -84,7 +84,7 @@ class Container extends Illuminate
         try {
             Dotenv::create(Env::getRepository(), $this->path)->safeLoad();
         } catch (InvalidFileException $e) {
-            $output = (new ConsoleOutput)->getErrorOutput();
+            $output = (new ConsoleOutput())->getErrorOutput();
 
             $output->writeln('The environment file is invalid!');
             $output->writeln($e->getMessage());

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -58,7 +58,7 @@ class Handler implements ExceptionHandler
         }
 
         if ($e instanceof SymfonyConsoleExceptionInterface) {
-            (new ConsoleApplication)->renderThrowable($e, $output);
+            (new ConsoleApplication())->renderThrowable($e, $output);
 
             return;
         }
@@ -79,7 +79,7 @@ class Handler implements ExceptionHandler
 
         $e = $this->mapException($e);
 
-        /** @var \NunoMaduro\Collision\Provider $provider */
+        /** @var Provider $provider */
         $provider = app(Provider::class);
 
         $handler = $provider->register()->getHandler()->setOutput($output);

--- a/src/Parsers/CommonMarkParser.php
+++ b/src/Parsers/CommonMarkParser.php
@@ -19,13 +19,13 @@ class CommonMarkParser implements MarkdownParserContract
     {
         $environment = new Environment(Arr::get(app('config'), 'commonmark.config', []));
 
-        $environment->addExtension(new CommonMarkCoreExtension);
+        $environment->addExtension(new CommonMarkCoreExtension());
 
         collect(Arr::get(app('config'), 'commonmark.extensions', [
-            new AttributesExtension,
-            new SmartPunctExtension,
-            new StrikethroughExtension,
-            new TableExtension,
+            new AttributesExtension(),
+            new SmartPunctExtension(),
+            new StrikethroughExtension(),
+            new TableExtension(),
         ]))->map(fn ($extension) => $environment->addExtension($extension));
 
         $this->converter = new MarkdownConverter($environment);

--- a/src/Parsers/MarkdownParser.php
+++ b/src/Parsers/MarkdownParser.php
@@ -8,9 +8,9 @@ class MarkdownParser implements FrontYAMLMarkdownParserInterface
 {
     public $parser;
 
-    public function __construct(MarkdownParserContract $parser = null)
+    public function __construct(?MarkdownParserContract $parser = null)
     {
-        $this->parser = $parser ?? new JigsawMarkdownParser;
+        $this->parser = $parser ?? new JigsawMarkdownParser();
     }
 
     public function __get($property)

--- a/src/Providers/CollectionServiceProvider.php
+++ b/src/Providers/CollectionServiceProvider.php
@@ -28,7 +28,7 @@ class CollectionServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        $this->app->bind('outputPathResolver', fn () => new BasicOutputPathResolver);
+        $this->app->bind('outputPathResolver', fn () => new BasicOutputPathResolver());
 
         $this->registerHandlers();
         $this->registerPathResolver();
@@ -100,7 +100,7 @@ class CollectionServiceProvider extends ServiceProvider
         $this->app->bind(SiteBuilder::class, function (Container $app) {
             return new SiteBuilder($app['files'], $app->cachePath(), $app['outputPathResolver'], $app['consoleOutput'], [
                 $app[CollectionItemHandler::class],
-                new IgnoredHandler,
+                new IgnoredHandler(),
                 $app[PaginatedPageHandler::class],
                 $app[MarkdownHandler::class],
                 $app[BladeHandler::class],

--- a/src/Providers/CompatibilityServiceProvider.php
+++ b/src/Providers/CompatibilityServiceProvider.php
@@ -11,6 +11,6 @@ class CompatibilityServiceProvider extends ServiceProvider
     {
         $this->app->instance('cwd', $this->app->path());
 
-        $this->app->singleton('consoleOutput', fn () => new ConsoleOutput);
+        $this->app->singleton('consoleOutput', fn () => new ConsoleOutput());
     }
 }

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -13,6 +13,6 @@ class EventServiceProvider extends ServiceProvider
     {
         $this->app->singleton('dispatcher', fn (Container $app) => new Dispatcher($app));
 
-        $this->app->singleton('events', fn (Container $app) => new EventBus);
+        $this->app->singleton('events', fn (Container $app) => new EventBus());
     }
 }

--- a/src/Providers/FilesystemServiceProvider.php
+++ b/src/Providers/FilesystemServiceProvider.php
@@ -9,6 +9,6 @@ class FilesystemServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        $this->app->singleton('files', fn () => new Filesystem);
+        $this->app->singleton('files', fn () => new Filesystem());
     }
 }

--- a/src/Providers/MarkdownServiceProvider.php
+++ b/src/Providers/MarkdownServiceProvider.php
@@ -21,7 +21,7 @@ class MarkdownServiceProvider extends ServiceProvider
         $this->app->bind(YAMLParser::class, SymfonyYAMLParser::class);
 
         $this->app->bind(MarkdownParserContract::class, function (Container $app) {
-            return $app['config']->get('commonmark') ? new CommonMarkParser : new JigsawMarkdownParser;
+            return $app['config']->get('commonmark') ? new CommonMarkParser() : new JigsawMarkdownParser();
         });
 
         $this->app->singleton('markdownParser', fn (Container $app) => new MarkdownParser($app[MarkdownParserContract::class]));

--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -29,7 +29,7 @@ class ViewServiceProvider extends ServiceProvider
         $this->registerEngineResolvers();
 
         (new BladeDirectivesFile($this->app->path('blade.php'), $this->app['blade.compiler']))->register();
-        $this->app->bind(ViewRenderer::class, fn () => new ViewRenderer);
+        $this->app->bind(ViewRenderer::class, fn () => new ViewRenderer());
         $this->app->bind(TemporaryFilesystem::class, fn (Container $app) => new TemporaryFilesystem($app->cachePath()));
 
         // TODO
@@ -74,7 +74,7 @@ class ViewServiceProvider extends ServiceProvider
     private function registerEngineResolvers(): void
     {
         $this->app->singleton('view.engine.resolver', function (Container $app) {
-            $resolver = new EngineResolver;
+            $resolver = new EngineResolver();
             $compilerEngine = new CompilerEngine($app['blade.compiler'], $app['files']);
 
             // Same as Laravel

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -7,13 +7,13 @@ use Illuminate\Support\Str;
 use Symfony\Component\VarDumper\VarDumper;
 
 if (! function_exists('app')) {
-    function app(string $abstract = null, array $parameters = []): mixed
+    function app(?string $abstract = null, array $parameters = []): mixed
     {
         if (is_null($abstract)) {
-            return \TightenCo\Jigsaw\Container::getInstance();
+            return TightenCo\Jigsaw\Container::getInstance();
         }
 
-        return \TightenCo\Jigsaw\Container::getInstance()->make($abstract, $parameters);
+        return TightenCo\Jigsaw\Container::getInstance()->make($abstract, $parameters);
     }
 }
 

--- a/stubs/site/bootstrap.php
+++ b/stubs/site/bootstrap.php
@@ -2,8 +2,8 @@
 
 use TightenCo\Jigsaw\Jigsaw;
 
-/** @var \Illuminate\Container\Container $container */
-/** @var \TightenCo\Jigsaw\Events\EventBus $events */
+/** @var Illuminate\Container\Container $container */
+/** @var TightenCo\Jigsaw\Events\EventBus $events */
 
 /*
  * You can run custom code at different stages of the build process by

--- a/tests/CommonMarkTest.php
+++ b/tests/CommonMarkTest.php
@@ -57,7 +57,7 @@ class CommonMarkTest extends TestCase
         $this->buildSite($files, [
             'commonmark' => [
                 'extensions' => [
-                    new DescriptionListExtension,
+                    new DescriptionListExtension(),
                 ],
             ],
         ]);
@@ -74,7 +74,7 @@ class CommonMarkTest extends TestCase
         $files = $this->withContent('### Heading {.class}');
 
         $this->app->bind(MarkdownParserContract::class, function () {
-            return new class implements MarkdownParserContract {
+            return new class() implements MarkdownParserContract {
                 public function parse(string $text)
                 {
                     return <<<EOT

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -55,7 +55,7 @@ class EventsTest extends TestCase
     /** @test */
     public function it_can_handle_invokable_listeners()
     {
-        $this->app['events']->beforeBuild(new class {
+        $this->app['events']->beforeBuild(new class() {
             private $object;
 
             public function __construct()

--- a/tests/JigsawMacroTest.php
+++ b/tests/JigsawMacroTest.php
@@ -23,7 +23,7 @@ class JigsawMacroTest extends TestCase
      */
     public function jigsaw_mixin_function_calls_successfully()
     {
-        Jigsaw::mixin(new JigsawMixinTestClass);
+        Jigsaw::mixin(new JigsawMixinTestClass());
 
         $this->assertSame('Reed', Jigsaw::getNameMixin());
     }

--- a/tests/SnapshotsTest.php
+++ b/tests/SnapshotsTest.php
@@ -22,12 +22,12 @@ class SnapshotsTest extends PHPUnit
     {
         parent::setUp();
 
-        $this->filesystem = new Filesystem;
+        $this->filesystem = new Filesystem();
     }
 
     public function snapshots(): array
     {
-        return collect((new Filesystem)->directories($this->source()))
+        return collect((new Filesystem())->directories($this->source()))
             ->map(fn ($path) => basename($path))
             ->reject(fn ($name) => Str::endsWith($name, '_snapshot'))
             // Prepend the test command with JIGSAW_SNAPSHOTS=<snapshot-names> to run specific snapshot tests

--- a/tests/SnapshotsTest.php
+++ b/tests/SnapshotsTest.php
@@ -46,7 +46,7 @@ class SnapshotsTest extends PHPUnit
     public function build(string $name)
     {
         // Delete the contents of the output directory in the source to clean up previous builds
-        $this->filesystem->deleteDirectory($this->output($name), true);
+        $this->filesystem->deleteDirectory($this->testOutput($name), true);
 
         $jigsaw = realpath(implode('/', array_filter([__DIR__, '..', 'jigsaw'])));
         $arguments = static::$arguments[$name] ?? [];
@@ -63,19 +63,19 @@ class SnapshotsTest extends PHPUnit
 
     private function assertSnapshotMatches($name)
     {
-        $this->assertDirectoryExists($this->output($name));
+        $this->assertDirectoryExists($this->testOutput($name));
 
         $this->assertSame(
             collect($this->filesystem->allFiles($this->snapshot($name), true))
                 ->map(fn ($file) => Str::after($file->getPathname(), $this->snapshot($name)))
                 ->toArray(),
-            collect($this->filesystem->allFiles($this->output($name), true))
-                ->map(fn ($file) => Str::after($file->getPathname(), $this->output($name)))
+            collect($this->filesystem->allFiles($this->testOutput($name), true))
+                ->map(fn ($file) => Str::after($file->getPathname(), $this->testOutput($name)))
                 ->toArray(),
             "Output file structure does not match snapshot in '{$name}'.",
         );
 
-        collect($this->filesystem->allFiles($this->output($name), true))->map(function (SplFileInfo $file) use ($name) {
+        collect($this->filesystem->allFiles($this->testOutput($name), true))->map(function (SplFileInfo $file) use ($name) {
             $this->assertSame(
                 file_get_contents(implode(DIRECTORY_SEPARATOR, array_filter([$this->snapshot($name), $file->getRelativePathname()]))),
                 $file->getContents(),
@@ -89,7 +89,7 @@ class SnapshotsTest extends PHPUnit
         return implode(DIRECTORY_SEPARATOR, array_filter([__DIR__, 'snapshots', $name]));
     }
 
-    private function output(string $name): string
+    private function testOutput(string $name): string
     {
         $output = $name === 'environment-specific-config-file' ? 'build_staging' : 'build_local';
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,11 +26,11 @@ class TestCase extends PHPUnit
     protected Filesystem $filesystem;
     protected string $tmp;
 
-    public function __construct($name = null, array $data = [], $dataName = '') 
+    public function __construct(string $name = 'Jigsaw')
     {
-        parent::__construct($name, $data, $dataName);
+        parent::__construct($name);
 
-        $this->filesystem = new Filesystem;
+        $this->filesystem = new Filesystem();
     }
 
     protected function setUp(): void
@@ -39,7 +39,7 @@ class TestCase extends PHPUnit
 
         $this->createTmp();
 
-        $this->app = new Container;
+        $this->app = new Container();
         /* @internal The '__testing' binding is for Jigsaw development only and may be removed. */
         $this->app->instance('__testing', true);
         $this->app->singleton(
@@ -47,7 +47,7 @@ class TestCase extends PHPUnit
             \TightenCo\Jigsaw\Exceptions\Handler::class,
         );
         $this->app->bootstrapWith([
-            \TightenCo\Jigsaw\Bootstrap\HandleExceptions::class,
+            HandleExceptions::class,
         ]);
 
         $this->app->buildPath = [
@@ -209,7 +209,7 @@ class TestCase extends PHPUnit
         return str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
     }
 
-    protected function assertOutputFile(string $path, string $contents, string $message = null): void
+    protected function assertOutputFile(string $path, string $contents, ?string $message = null): void
     {
         static::assertStringEqualsFile(
             $this->tmpPath($path),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,9 +26,9 @@ class TestCase extends PHPUnit
     protected Filesystem $filesystem;
     protected string $tmp;
 
-    public function __construct()
+    public function __construct($name = null, array $data = [], $dataName = '') 
     {
-        parent::__construct("Jigsaw");
+        parent::__construct($name, $data, $dataName);
 
         $this->filesystem = new Filesystem;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,7 +28,7 @@ class TestCase extends PHPUnit
 
     public function __construct()
     {
-        parent::__construct();
+        parent::__construct("Jigsaw");
 
         $this->filesystem = new Filesystem;
     }


### PR DESCRIPTION
I am updatating jigsaw's packages to get to a point where I can add laravel/prompts
PHPUnit 11 seems to have a BC break - anyone know about this? 

TBC This PR is not ready yet I am just trying to get other eyes on the PHPUnit issue.

```
An error occurred inside PHPUnit.

Message:  Too few arguments to function PHPUnit\Framework\TestCase::__construct(), 0 passed in /Users/nigeljames/OS/jigsaw/tests/TestCase.php on line 31 and exactly 1 expected
Location: /Users/nigeljames/OS/jigsaw/vendor/phpunit/phpunit/src/Framework/TestCase.php:224
```

I have resolved this with https://stackoverflow.com/a/66676166 and I am now working on other updates with Symphony packages.

