### PR TITLE
Bump dependencies to support Illuminate v11 components

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3']
+        php: ['8.2', '8.3']
         dependencies: [lowest, highest]
         include:
           - php: '8.3'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 vendor/
 .php-cs-fixer.cache
-.phpunit.result.cache
+.phpunit.cache/
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -18,30 +18,30 @@
         }
     ],
     "require": {
-        "php": "^8.0.2 <8.4",
-        "illuminate/collections": "^9.0",
-        "illuminate/console": "^9.21.1",
-        "illuminate/container": "^9.0",
-        "illuminate/filesystem": "^9.0",
-        "illuminate/support": "^9.0",
-        "illuminate/view": "^9.8",
+        "php": "^8.2",
+        "illuminate/collections": "^11.0",
+        "illuminate/console": "^11.0",
+        "illuminate/container": "^11.0",
+        "illuminate/filesystem": "^11.0",
+        "illuminate/support": "^11.0",
+        "illuminate/view": "^11.0",
         "league/commonmark": "^2.4",
-        "michelf/php-markdown": "^1.9",
-        "mnapoli/front-yaml": "^1.5",
-        "nunomaduro/collision": "^6.0",
-        "spatie/laravel-ignition": "^1.6",
-        "symfony/console": "^5.4 || ^6.0",
-        "symfony/error-handler": "^5.0 || ^6.0",
-        "symfony/finder": "^5.3.7 || ^6.0",
-        "symfony/process": "^5.0 || ^6.0",
-        "symfony/var-dumper": "^5.0 || ^6.0",
-        "symfony/yaml": "^5.0 || ^6.0",
-        "vlucas/phpdotenv": "^5.3.1"
+        "michelf/php-markdown": "^2.0",
+        "mnapoli/front-yaml": "^2.0",
+        "nunomaduro/collision": "^8.1",
+        "spatie/laravel-ignition": "^2.4",
+        "symfony/console": "^6.0 || ^7.0",
+        "symfony/error-handler": "^6.0 || ^7.0",
+        "symfony/finder": "^6.0 || ^7.0",
+        "symfony/process": "^6.0 || ^7.0",
+        "symfony/var-dumper": "^6.0 || ^7.0",
+        "symfony/yaml": "^6.0 || ^7.0",
+        "vlucas/phpdotenv": "^5.6"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.17",
-        "mockery/mockery": "^1.4",
-        "phpunit/phpunit": "^9.3.3"
+        "friendsofphp/php-cs-fixer": "^3.51",
+        "mockery/mockery": "^1.6",
+        "phpunit/phpunit": "^11.0.6"
     },
     "autoload": {
         "psr-4": {
@@ -60,7 +60,7 @@
         "jigsaw"
     ],
     "scripts": {
-        "format" : "php-cs-fixer fix --verbose"
+        "format": "php-cs-fixer fix --verbose"
     },
     "config": {
         "sort-packages": true,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php" colors="true" convertDeprecationsToExceptions="true">
-    <testsuites>
-        <testsuite name="Jigsaw Tests">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Jigsaw Tests">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -8,11 +8,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class Command extends SymfonyCommand
 {
-    protected $input;
-    protected $output;
+    protected InputInterface  $input;
+    protected OutputInterface $output;
     protected $console;
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->input = $input;
         $this->output = $output;

--- a/src/IterableObject.php
+++ b/src/IterableObject.php
@@ -2,12 +2,14 @@
 
 namespace TightenCo\Jigsaw;
 
+use AllowDynamicProperties;
 use ArrayAccess;
 use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\HigherOrderCollectionProxy;
 
+#[AllowDynamicProperties]
 class IterableObject extends BaseCollection implements ArrayAccess
 {
     public function __get($key)

--- a/src/Parsers/MarkdownParser.php
+++ b/src/Parsers/MarkdownParser.php
@@ -23,7 +23,7 @@ class MarkdownParser implements FrontYAMLMarkdownParserInterface
         $this->parser->$property = $value;
     }
 
-    public function parse($markdown)
+    public function parse($markdown): string
     {
         return $this->parser->parse($markdown);
     }

--- a/tests/AtSymbolInMarkdownTest.php
+++ b/tests/AtSymbolInMarkdownTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class AtSymbolInMarkdownTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function mailto_link_in_markdown_is_parsed_and_obfuscated()
     {
         $files = $this->setupSource([
@@ -24,9 +24,7 @@ class AtSymbolInMarkdownTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function mailto_link_in_blade_markdown_is_parsed()
     {
         $files = $this->setupSource([
@@ -44,9 +42,7 @@ class AtSymbolInMarkdownTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function at_symbol_after_closing_bracket_is_unchanged_in_markdown()
     {
         $files = $this->setupSource([
@@ -64,9 +60,7 @@ class AtSymbolInMarkdownTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function double_at_symbol_in_fenced_code_block_is_parsed_to_single_at_symbol_in_blade_markdown()
     {
         $files = $this->setupSource([
@@ -84,9 +78,7 @@ class AtSymbolInMarkdownTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function double_at_symbol_in_inline_code_block_is_parsed_to_single_at_symbol_in_blade_markdown()
     {
         $files = $this->setupSource([

--- a/tests/BladeComponentTest.php
+++ b/tests/BladeComponentTest.php
@@ -4,12 +4,11 @@ namespace Tests;
 
 use Illuminate\Container\Container;
 use Illuminate\View\Component;
+use PHPUnit\Framework\Attributes\Test;
 
 class BladeComponentTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function can_include_blade_component_with_at_syntax()
     {
         $files = $this->setupSource([
@@ -42,9 +41,7 @@ class BladeComponentTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_include_blade_component_with_x_tag_syntax_using_underscore_components_directory()
     {
         $files = $this->setupSource([
@@ -64,9 +61,7 @@ class BladeComponentTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_include_blade_component_with_x_tag_syntax_using_aliased_component_with_view()
     {
         $this->app['bladeCompiler']->component('alert', AlertComponent::class);
@@ -88,9 +83,7 @@ class BladeComponentTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_include_blade_component_with_x_tag_syntax_using_aliased_component_with_inline_render()
     {
         $this->app['bladeCompiler']->component('inline', InlineAlertComponent::class);
@@ -109,9 +102,7 @@ class BladeComponentTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_include_blade_component_with_x_tag_syntax_using_namespaced_component_with_inline_render()
     {
         class_alias('Tests\InlineAlertComponent', 'Components\InlineClassComponent');
@@ -130,9 +121,7 @@ class BladeComponentTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_include_blade_component_with_x_tag_syntax_using_namespaced_component_with_view()
     {
         class_alias('Tests\\AlertComponent', 'Components\\ClassComponent');

--- a/tests/CollectionItemTest.php
+++ b/tests/CollectionItemTest.php
@@ -2,13 +2,12 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\Collection\CollectionItem;
 
 class CollectionItemTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_item_contents_are_returned_when_item_is_referenced_as_a_string()
     {
         $config = collect(['collections' => ['collection' => []]]);
@@ -33,9 +32,7 @@ class CollectionItemTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_item_can_be_filtered()
     {
         $config = collect(['collections' => [
@@ -80,9 +77,7 @@ class CollectionItemTest extends TestCase
         $this->assertFileExists($this->tmpPath('build/collection/item.html'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_item_can_be_mapped()
     {
         $config = collect(['collections' => [
@@ -120,9 +115,7 @@ class CollectionItemTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_item_page_metadata_contains_path()
     {
         $config = collect(['collections' => ['collection' => []]]);
@@ -143,9 +136,7 @@ class CollectionItemTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_item_page_metadata_contains_relative_path()
     {
         $config = collect(['collections' => ['collection' => []]]);
@@ -168,9 +159,7 @@ class CollectionItemTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_item_page_metadata_contains_extension()
     {
         $config = collect(['collections' => ['collection' => []]]);
@@ -191,9 +180,7 @@ class CollectionItemTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_item_page_metadata_contains_collection_name()
     {
         $config = collect(['collections' => ['collection' => []]]);
@@ -219,9 +206,7 @@ class CollectionItemTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_item_page_metadata_contains_source_path()
     {
         $config = collect(['collections' => ['collection' => []]]);
@@ -242,9 +227,7 @@ class CollectionItemTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_item_page_metadata_contains_modified_time()
     {
         $config = collect(['collections' => ['collection' => []]]);

--- a/tests/CommonMarkTest.php
+++ b/tests/CommonMarkTest.php
@@ -3,11 +3,12 @@
 namespace Tests;
 
 use League\CommonMark\Extension\DescriptionList\DescriptionListExtension;
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\Parsers\MarkdownParserContract;
 
 class CommonMarkTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function enable_commonmark_parser()
     {
         $files = $this->withContent('### Heading {.class}');
@@ -22,7 +23,7 @@ class CommonMarkTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function configure_commonmark_parser()
     {
         $files = $this->withContent('_Em_');
@@ -43,7 +44,7 @@ class CommonMarkTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function replace_commonmark_extensions()
     {
         $files = $this->withContent(<<<MD
@@ -68,7 +69,7 @@ class CommonMarkTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function override_parser_with_custom_class()
     {
         $files = $this->withContent('### Heading {.class}');

--- a/tests/ConfigVariableTest.php
+++ b/tests/ConfigVariableTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class ConfigVariableTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function config_variables_are_replaced_with_values_in_blade_templates()
     {
         $config = collect(['variable' => 'value']);
@@ -22,9 +22,7 @@ class ConfigVariableTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function config_variables_are_overridden_by_local_variables_in_blade_templates()
     {
         $config = collect(['variable' => 'config']);

--- a/tests/CustomCommandTest.php
+++ b/tests/CustomCommandTest.php
@@ -2,15 +2,14 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use TightenCo\Jigsaw\Console\Command;
 
 class CustomCommandTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function custom_command_with_no_arguments()
     {
         $this->createSource([]);

--- a/tests/CustomScaffoldInstallerTest.php
+++ b/tests/CustomScaffoldInstallerTest.php
@@ -3,6 +3,8 @@
 namespace Tests;
 
 use Mockery;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\Console\ConsoleSession;
 use TightenCo\Jigsaw\File\Filesystem;
 use TightenCo\Jigsaw\Scaffold\CustomInstaller;
@@ -12,9 +14,7 @@ use TightenCo\Jigsaw\Scaffold\ProcessRunner;
 
 class CustomScaffoldInstallerTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function custom_installer_installs_basic_scaffold_files()
     {
         $this->createSource([]);
@@ -32,9 +32,7 @@ class CustomScaffoldInstallerTest extends TestCase
         $this->assertFileExists($this->tmpPath('config.php'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_deletes_single_base_file_specified_in_delete_array()
     {
         $this->createSource([]);
@@ -49,9 +47,7 @@ class CustomScaffoldInstallerTest extends TestCase
         $this->assertFileExists($this->tmpPath('source'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_deletes_multiple_base_files_specified_in_delete_array()
     {
         $this->createSource([]);
@@ -70,9 +66,7 @@ class CustomScaffoldInstallerTest extends TestCase
         $this->assertFileExists($this->tmpPath('source'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_deletes_base_directories_specified_in_delete_array()
     {
         $this->createSource([]);
@@ -88,9 +82,7 @@ class CustomScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('source'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_copies_all_preset_files_if_copy_has_no_parameter()
     {
         $this->createSource([
@@ -116,9 +108,7 @@ class CustomScaffoldInstallerTest extends TestCase
         $this->assertFileExists($this->tmpPath('source/source-file.md'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_copies_individual_preset_file_if_copy_parameter_is_string()
     {
         $this->createSource([
@@ -144,9 +134,7 @@ class CustomScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('source/source-file.md'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_copies_multiple_preset_files_if_copy_parameter_is_array()
     {
         $this->createSource([
@@ -175,9 +163,7 @@ class CustomScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('.dotfile'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_can_copy_files_using_a_wildcard()
     {
         $this->createSource([
@@ -203,9 +189,7 @@ class CustomScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('.dotfile'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_can_call_copy_multiple_times()
     {
         $this->createSource([
@@ -232,9 +216,7 @@ class CustomScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('preset-file.php'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_copies_from_specified_directory_to_root_if_from_is_specified()
     {
         $this->createSource([
@@ -264,9 +246,7 @@ class CustomScaffoldInstallerTest extends TestCase
         $this->assertOutputFile('config.php', 'config 2');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_can_ignore_preset_files_when_copying()
     {
         $this->createSource([
@@ -293,9 +273,7 @@ class CustomScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('.dotfile'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_can_call_ignore_multiple_times()
     {
         $this->createSource([
@@ -323,9 +301,7 @@ class CustomScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('.dotfile'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function original_composer_json_is_not_deleted()
     {
         $old_composer = [
@@ -356,9 +332,7 @@ class CustomScaffoldInstallerTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function original_composer_json_is_merged_with_new_composer_json_after_copy()
     {
         $old_composer = [
@@ -398,9 +372,7 @@ class CustomScaffoldInstallerTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function composer_json_files_are_merged_when_copying_multiple_times()
     {
         $old_composer = [
@@ -450,9 +422,7 @@ class CustomScaffoldInstallerTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function empty_composer_json_is_created_if_it_was_not_present_before_preset_was_installed()
     {
         $this->createSource([
@@ -477,10 +447,8 @@ class CustomScaffoldInstallerTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function installer_can_ask_for_user_input()
     {
         $console = Mockery::spy(ConsoleSession::class);
@@ -495,10 +463,8 @@ class CustomScaffoldInstallerTest extends TestCase
             ->with('What is your name?', null, null, null);
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function installer_can_ask_for_user_input_with_choices()
     {
         $console = Mockery::spy(ConsoleSession::class);
@@ -522,10 +488,8 @@ class CustomScaffoldInstallerTest extends TestCase
             );
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function installer_can_ask_for_user_confirmation()
     {
         $console = Mockery::spy(ConsoleSession::class);
@@ -540,10 +504,8 @@ class CustomScaffoldInstallerTest extends TestCase
             ->with('Continue?', null);
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function installer_runs_specified_commands_from_init()
     {
         $package = Mockery::mock(PresetPackage::class);

--- a/tests/DefaultScaffoldInstallerTest.php
+++ b/tests/DefaultScaffoldInstallerTest.php
@@ -4,6 +4,8 @@ namespace Tests;
 
 use Illuminate\Support\Arr;
 use Mockery;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\File\Filesystem;
 use TightenCo\Jigsaw\Scaffold\DefaultInstaller;
 use TightenCo\Jigsaw\Scaffold\PresetPackage;
@@ -12,9 +14,7 @@ use TightenCo\Jigsaw\Scaffold\ProcessRunner;
 
 class DefaultScaffoldInstallerTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_installs_basic_scaffold_files()
     {
         $this->createSource([]);
@@ -31,9 +31,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertFileExists($this->tmpPath('config.php'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_deletes_single_base_file_specified_in_delete_array()
     {
         $this->createSource([]);
@@ -49,9 +47,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertFileExists($this->tmpPath('source'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_deletes_multiple_base_files_specified_in_delete_array()
     {
         $this->createSource([]);
@@ -68,9 +64,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertFileExists($this->tmpPath('source'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_deletes_base_directories_specified_in_delete_array()
     {
         $this->createSource([]);
@@ -85,9 +79,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('source'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_copies_all_preset_files()
     {
         $this->createSource([
@@ -120,9 +112,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertFileExists($this->tmpPath('empty'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_preserves_base_files_when_copying_preset_files()
     {
         $this->createSource([
@@ -140,9 +130,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertFileExists($this->tmpPath('config.php'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_overwrites_base_files_of_same_name_when_copying_preset_files()
     {
         $this->createSource([
@@ -160,9 +148,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertOutputFile('config.php', 'new config file from preset');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_can_ignore_files_and_directories_from_preset_when_copying()
     {
         $this->createSource([
@@ -196,9 +182,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('ignore-directory'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_can_ignore_files_and_directories_from_preset_using_wildcard_when_copying()
     {
         $this->createSource([
@@ -231,9 +215,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('ignore-directory'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_ignores_node_modules_directory_from_preset_when_copying()
     {
         $this->createSource([
@@ -251,9 +233,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('node_modules'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_ignores_vendor_directory_from_preset_when_copying()
     {
         $this->createSource([
@@ -271,9 +251,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('vendor'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_ignores_init_file_from_preset_when_copying()
     {
         $this->createSource([
@@ -291,9 +269,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('init.php'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function installer_ignores_build_directories_from_preset_when_copying()
     {
         $this->createSource([
@@ -313,10 +289,8 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertFileMissing($this->tmpPath('build_production'));
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function installer_runs_default_commands_if_none_are_specified_in_init()
     {
         $builder = Mockery::spy(PresetScaffoldBuilder::class);
@@ -332,10 +306,8 @@ class DefaultScaffoldInstallerTest extends TestCase
         $builder->shouldHaveReceived('runCommands')->with($installer::DEFAULT_COMMANDS);
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function installer_runs_no_commands_if_empty_array_is_specified_in_init()
     {
         $builder = Mockery::spy(PresetScaffoldBuilder::class);
@@ -351,10 +323,8 @@ class DefaultScaffoldInstallerTest extends TestCase
         $builder->shouldHaveReceived('runCommands')->with([]);
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function installer_runs_specified_commands_from_init()
     {
         $builder = Mockery::spy(PresetScaffoldBuilder::class);
@@ -370,9 +340,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $builder->shouldHaveReceived('runCommands')->with(['yarn']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function composer_json_is_restored_if_deleted_after_preset_is_installed()
     {
         $old_composer = [
@@ -398,9 +366,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertEquals($old_composer, json_decode(file_get_contents($this->tmpPath('composer.json')), true));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function original_composer_json_is_merged_with_composer_json_installed_by_preset()
     {
         $old_composer = [
@@ -435,9 +401,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertEquals('setting', Arr::get($new_composer, 'repository'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function version_constraints_from_original_composer_json_take_precedence_in_merged_composer_json()
     {
         $old_composer = [
@@ -472,9 +436,7 @@ class DefaultScaffoldInstallerTest extends TestCase
         $this->assertEquals('3.0', Arr::get($new_composer, 'require.new-package/test'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function empty_composer_json_is_created_if_it_was_not_present_before_preset_was_installed()
     {
         $this->createSource([

--- a/tests/DotInFileNameTest.php
+++ b/tests/DotInFileNameTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\Handlers\BladeHandler;
 use TightenCo\Jigsaw\Handlers\MarkdownHandler;
 use TightenCo\Jigsaw\IterableObject;
@@ -12,9 +13,7 @@ use TightenCo\Jigsaw\PathResolvers\PrettyOutputPathResolver;
 
 class DotInFileNameTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function md_files_with_dot_in_filename_are_processed()
     {
         $inputFile = $this->getInputFile('dot-files/filename-with.dot.1.md');
@@ -27,9 +26,7 @@ class DotInFileNameTest extends TestCase
         $this->assertStringContainsString('<h3>This file contains a dot in the filename</h3>', $outputFile[0]->contents());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function blade_md_hybrid_files_with_dot_in_filename_are_processed()
     {
         $inputFile = $this->getInputFile('dot-files/filename-with.dot.2.blade.md');
@@ -42,9 +39,7 @@ class DotInFileNameTest extends TestCase
         $this->assertStringContainsString('<h3>This file also contains a dot in the filename</h3>', $outputFile[0]->contents());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function blade_files_with_dot_in_filename_are_processed()
     {
         $inputFile = $this->getInputFile('dot-files/filename-with.dot.3.blade.php');
@@ -57,9 +52,7 @@ class DotInFileNameTest extends TestCase
         $this->assertStringContainsString('<h3>This file contains a dot in the filename</h3>', $outputFile[0]->contents());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function dot_in_filename_is_preserved_for_collection_item_with_default_path_config()
     {
         $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());
@@ -70,9 +63,7 @@ class DotInFileNameTest extends TestCase
         $this->assertEquals('/collection-item-with.dot', $outputPath[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function dot_in_filename_is_preserved_for_collection_item_with_shorthand_path_config()
     {
         $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());
@@ -83,9 +74,7 @@ class DotInFileNameTest extends TestCase
         $this->assertEquals('/collection-item-with.dot', $outputPath[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function dot_in_filename_is_preserved_for_collection_item_with_slugified_shorthand_path_config()
     {
         $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class EventsTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_add_event_listeners_as_closures()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$a) {
@@ -29,9 +29,7 @@ class EventsTest extends TestCase
         $this->assertEquals(789, $c);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_add_event_listeners_as_classes()
     {
         $this->app['events']->beforeBuild(TestListener::class);
@@ -40,9 +38,7 @@ class EventsTest extends TestCase
         $this->assertEquals('set in TestListener', $jigsaw->getConfig('variable_a'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multiple_event_listeners_are_fired_in_the_order_they_were_defined()
     {
         $this->app['events']->beforeBuild([TestListener::class, TestListenerTwo::class]);
@@ -52,7 +48,7 @@ class EventsTest extends TestCase
         $this->assertEquals('set in TestListener', $jigsaw->getConfig('variable_b'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_handle_invokable_listeners()
     {
         $this->app['events']->beforeBuild(new class {
@@ -73,9 +69,7 @@ class EventsTest extends TestCase
         $this->assertEquals('Set from invokable', $jigsaw->getConfig('variable_a'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function listeners_for_undefined_events_are_ignored()
     {
         $this->app['events']->someUndefinedEvent(function ($jigsaw) use (&$result) {
@@ -86,9 +80,7 @@ class EventsTest extends TestCase
         $this->assertNull($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_retrieve_environment_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -99,9 +91,7 @@ class EventsTest extends TestCase
         $this->assertEquals('test', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_retrieve_all_config_variables_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -112,9 +102,7 @@ class EventsTest extends TestCase
         $this->assertEquals('value', $result->test_variable);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_retrieve_specific_config_variable_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -125,9 +113,7 @@ class EventsTest extends TestCase
         $this->assertEquals('value', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_add_a_new_config_variable_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -141,9 +127,7 @@ class EventsTest extends TestCase
         $this->assertEquals('value', $result->getConfig('new_variable'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_update_an_existing_config_variable_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -156,9 +140,7 @@ class EventsTest extends TestCase
         $this->assertEquals('new value', $result->getConfig('test_variable'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_get_a_nested_config_variable_with_dot_notation_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -173,9 +155,7 @@ class EventsTest extends TestCase
         $this->assertEquals('value', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_add_a_nested_config_variable_with_dot_notation_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -193,9 +173,7 @@ class EventsTest extends TestCase
         $this->assertEquals('original value', $result->getConfig('test_variable')['existing_key']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_update_an_existing_nested_config_variable_with_dot_notation_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -212,9 +190,7 @@ class EventsTest extends TestCase
         $this->assertEquals('new value', $result->getConfig('test_variable')['nested']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_items_created_in_before_build_event_listener_are_output_to_filesystem()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -244,9 +220,7 @@ class EventsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_items_added_in_before_build_event_listener_are_output_to_filesystem()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -284,9 +258,7 @@ class EventsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_retrieve_a_collection_of_collection_names_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -302,9 +274,7 @@ class EventsTest extends TestCase
         $this->assertEquals(['posts', 'people'], $result->all());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_retrieve_a_collection_of_collection_items_in_event_listener()
     {
         $this->app['events']->afterCollections(function ($jigsaw) use (&$result) {
@@ -333,9 +303,7 @@ class EventsTest extends TestCase
         $this->assertEquals('Title for post #2', $result->post_2->title);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_items_cannot_be_retrieved_during_before_build_event()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -356,9 +324,7 @@ class EventsTest extends TestCase
         $this->assertNull($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_retrieve_source_path_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -369,9 +335,7 @@ class EventsTest extends TestCase
         $this->assertEquals("{$this->tmp}/source", $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_change_source_path_in_event_listener()
     {
         $this->createSource([
@@ -395,9 +359,7 @@ class EventsTest extends TestCase
         $this->assertOutputFile('build/file_in_new_source.html', 'new');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_retrieve_destination_path_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -408,9 +370,7 @@ class EventsTest extends TestCase
         $this->assertEquals("{$this->tmp}/build", $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_change_destination_path_in_event_listener()
     {
         $source = $this->setupSource(['file.html' => 'test']);
@@ -428,9 +388,7 @@ class EventsTest extends TestCase
         $this->assertEquals('test', $source->getChild('new_build/file.html')->getContent());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_read_the_contents_of_source_file_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -441,9 +399,7 @@ class EventsTest extends TestCase
         $this->assertEquals('## test', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_write_a_new_source_file_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -454,9 +410,7 @@ class EventsTest extends TestCase
         $this->assertEquals('## test', $source->getChild('source/file.md')->getContent());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_write_a_new_source_file_in_a_new_directory_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -467,9 +421,7 @@ class EventsTest extends TestCase
         $this->assertEquals('## test', $source->getChild('source/new_directory/file.md')->getContent());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_update_an_existing_source_file_in_event_listener()
     {
         $this->app['events']->beforeBuild(function ($jigsaw) use (&$result) {
@@ -480,9 +432,7 @@ class EventsTest extends TestCase
         $this->assertEquals('## updated', $source->getChild('source/file.md')->getContent());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_read_the_contents_of_an_output_file_in_after_build_event_listener()
     {
         $this->app['events']->afterBuild(function ($jigsaw) use (&$result) {
@@ -497,9 +447,7 @@ class EventsTest extends TestCase
         $this->assertEquals('<h1>test</h1>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_write_a_new_output_file_in_after_build_event_listener()
     {
         $this->app['events']->afterBuild(function ($jigsaw) use (&$result) {
@@ -510,9 +458,7 @@ class EventsTest extends TestCase
         $this->assertEquals('test', $source->getChild('build/file.html')->getContent());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_update_an_existing_output_file_in_after_build_event_listener()
     {
         $this->app['events']->afterBuild(function ($jigsaw) use (&$original, &$result) {
@@ -529,9 +475,7 @@ class EventsTest extends TestCase
         $this->assertEquals('<h1>revised test</h1>', $source->getChild('build/test/file.html')->getContent());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function user_can_write_a_new_output_file_in_a_new_directory_in_after_build_event_listener()
     {
         $this->app['events']->afterBuild(function ($jigsaw) use (&$result) {
@@ -542,7 +486,7 @@ class EventsTest extends TestCase
         $this->assertEquals('test', $source->getChild('build/new_directory/file.html')->getContent());
     }
 
-    /** @test */
+    #[Test]
     public function user_can_write_a_new_output_file_in_a_new_directory_in_after_build_event_listener_when_path_begins_with_slash()
     {
         $this->app['events']->afterBuild(function ($jigsaw) use (&$result) {

--- a/tests/FilePathTest.php
+++ b/tests/FilePathTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\IterableObject;
 use TightenCo\Jigsaw\PageVariable;
 use TightenCo\Jigsaw\PathResolvers\CollectionPathResolver;

--- a/tests/FilesystemTest.php
+++ b/tests/FilesystemTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\File\Filesystem;
 
 class FilesystemTest extends TestCase
@@ -22,9 +23,7 @@ class FilesystemTest extends TestCase
         'empty-directory' => [],
     ];
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_return_array_of_all_files_and_directories()
     {
         $filesystem = $this->app->make(Filesystem::class);
@@ -35,9 +34,7 @@ class FilesystemTest extends TestCase
         $this->assertCount(11, $files);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function DS_Store_is_always_ignored_when_retrieving_all_files_and_directories()
     {
         $this->createSource([
@@ -59,9 +56,7 @@ class FilesystemTest extends TestCase
         $this->assertCount(2, $files);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_ignore_a_file_when_retrieving_all_files_and_directories()
     {
         $files = $this->getFilesExcept('file-1.md');
@@ -70,9 +65,7 @@ class FilesystemTest extends TestCase
         $this->assertCount(10, $files);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_ignore_multiple_files_when_retrieving_all_files_and_directories()
     {
         $files = $this->getFilesExcept([
@@ -85,9 +78,7 @@ class FilesystemTest extends TestCase
         $this->assertCount(9, $files);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_use_wildcard_to_ignore_files_when_retrieving_all_files_and_directories()
     {
         $files = $this->getFilesExcept([
@@ -99,9 +90,7 @@ class FilesystemTest extends TestCase
         $this->assertCount(9, $files);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_use_wildcard_in_middle_of_filename_to_ignore_files_when_retrieving_all_files_and_directories()
     {
         $files = $this->getFilesExcept([
@@ -113,9 +102,7 @@ class FilesystemTest extends TestCase
         $this->assertCount(9, $files);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_use_wildcard_at_beginning_of_filename_to_ignore_files_when_retrieving_all_files_and_directories()
     {
         $files = $this->getFilesExcept([
@@ -127,9 +114,7 @@ class FilesystemTest extends TestCase
         $this->assertCount(9, $files);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_ignore_directories_when_retrieving_all_files_and_directories()
     {
         $files = $this->getFilesExcept([
@@ -140,9 +125,7 @@ class FilesystemTest extends TestCase
         $this->assertCount(4, $files);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function directory_slash_is_ignored_when_retrieving_all_files_and_directories()
     {
         $files = $this->getFilesExcept([
@@ -153,9 +136,7 @@ class FilesystemTest extends TestCase
         $this->assertCount(4, $files);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_ignore_nested_directories_when_retrieving_all_files_and_directories()
     {
         $files = $this->getFilesExcept([
@@ -166,9 +147,7 @@ class FilesystemTest extends TestCase
         $this->assertCount(8, $files);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_use_wildcard_to_ignore_nested_files_when_retrieving_all_files_and_directories()
     {
         $files = $this->getFilesExcept([
@@ -180,9 +159,7 @@ class FilesystemTest extends TestCase
         $this->assertCount(9, $files);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_use_multiple_wildcards_to_ignore_files_when_retrieving_all_files_and_directories()
     {
         $files = $this->getFilesExcept([
@@ -194,9 +171,7 @@ class FilesystemTest extends TestCase
         $this->assertCount(9, $files);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_return_array_of_files_and_directories_matching_a_string()
     {
         $filesystem = $this->app->make(Filesystem::class);
@@ -208,9 +183,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals('file-1.md', $files[0]->getFileName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_return_array_of_files_and_directories_matching_an_array()
     {
         $files = $this->getFilesMatching([
@@ -221,9 +194,7 @@ class FilesystemTest extends TestCase
         $this->assertEqualsCanonicalizing(['file-1.md', 'file-2.md'], $files->all());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_return_array_of_files_and_directories_matching_a_wildcard()
     {
         $files = $this->getFilesMatching([
@@ -233,9 +204,7 @@ class FilesystemTest extends TestCase
         $this->assertEqualsCanonicalizing(['file-1.md', 'file-2.md'], $files->all());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_return_array_of_files_and_directories_matching_a_directory()
     {
         $files = $this->getFilesMatching([

--- a/tests/Haiku.php
+++ b/tests/Haiku.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
 
 trait Haiku
 {

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -2,15 +2,17 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class HelpersTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function public_path_returns_path_to_specified_file_in_default_source_directory()
     {
         $this->assertEquals('source/some-file.md', public_path('some-file.md'));
     }
 
-    /** @test */
+    #[Test]
     public function public_path_returns_path_to_specified_file_in_custom_source_directory()
     {
         $this->app->config = collect([
@@ -22,13 +24,13 @@ class HelpersTest extends TestCase
         $this->assertEquals('src/some-file.md', public_path('some-file.md'));
     }
 
-    /** @test */
+    #[Test]
     public function leftTrimPath_leaves_leading_periods()
     {
         $this->assertEquals('.well-known', leftTrimPath('.well-known'));
     }
 
-    /** @test */
+    #[Test]
     public function url_helper_returns_absolute_url()
     {
         $this->app->config = collect(['baseUrl' => 'https://test.com/sub/']);
@@ -36,7 +38,7 @@ class HelpersTest extends TestCase
         $this->assertSame('https://test.com/sub/posts/my-first-post', url('posts/my-first-post'));
     }
 
-    /** @test */
+    #[Test]
     public function resolve_path_does_not_strip_0s()
     {
         $path = 'path/to/assets/0/0/0.png';

--- a/tests/InitCommandTest.php
+++ b/tests/InitCommandTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use TightenCo\Jigsaw\Console\InitCommand;
@@ -11,9 +12,7 @@ use TightenCo\Jigsaw\Scaffold\PresetScaffoldBuilder;
 
 class InitCommandTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function init_command_with_no_arguments_uses_basic_scaffold_for_site()
     {
         $basic_scaffold = Mockery::spy(BasicScaffoldBuilder::class);
@@ -35,9 +34,7 @@ class InitCommandTest extends TestCase
         $this->assertStringContainsString('initialized', $console->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function init_command_with_argument_uses_preset_scaffold_for_site()
     {
         $preset_scaffold = Mockery::spy(PresetScaffoldBuilder::class);
@@ -60,9 +57,7 @@ class InitCommandTest extends TestCase
         $this->assertStringContainsString('initialized', $console->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function init_command_displays_error_if_preset_name_is_invalid()
     {
         $command = $this->app->make(InitCommand::class);
@@ -73,9 +68,7 @@ class InitCommandTest extends TestCase
         $this->assertStringContainsString("'invalid' is not a valid package name.", $console->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function init_command_displays_warning_if_source_directory_exists()
     {
         $this->createSource(['source' => []]);
@@ -90,9 +83,7 @@ class InitCommandTest extends TestCase
         $this->assertStringContainsString("It looks like you've already run 'jigsaw init' on this project", $console->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function init_command_displays_warning_if_config_dot_php_exists()
     {
         $this->createSource(['config.php' => '']);
@@ -107,9 +98,7 @@ class InitCommandTest extends TestCase
         $this->assertStringContainsString("It looks like you've already run 'jigsaw init' on this project", $console->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function will_not_build_scaffold_if_site_already_initialized_and_user_chooses_cancel()
     {
         $basic_scaffold = Mockery::spy(BasicScaffoldBuilder::class);
@@ -133,9 +122,7 @@ class InitCommandTest extends TestCase
         $this->assertStringNotContainsString('initialized', $console->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function will_archive_existing_site_if_user_chooses_archive_option()
     {
         $basic_scaffold = Mockery::spy(BasicScaffoldBuilder::class);
@@ -158,9 +145,7 @@ class InitCommandTest extends TestCase
         $this->assertStringContainsString('initialized', $console->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function will_build_scaffold_if_site_already_initialized_and_user_chooses_archive()
     {
         $basic_scaffold = Mockery::spy(BasicScaffoldBuilder::class);
@@ -183,9 +168,7 @@ class InitCommandTest extends TestCase
         $this->assertStringContainsString('initialized', $console->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function will_delete_existing_site_if_user_chooses_delete_option()
     {
         $basic_scaffold = Mockery::spy(BasicScaffoldBuilder::class);
@@ -208,9 +191,7 @@ class InitCommandTest extends TestCase
         $this->assertStringContainsString('initialized', $console->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function will_build_scaffold_if_site_already_initialized_and_user_chooses_delete()
     {
         $basic_scaffold = Mockery::spy(BasicScaffoldBuilder::class);

--- a/tests/IterableObjectTest.php
+++ b/tests/IterableObjectTest.php
@@ -2,13 +2,12 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\IterableObject;
 
 class IterableObjectTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function item_in_iterable_object_can_be_referenced_as_object_property()
     {
         $iterable_object = new IterableObject([
@@ -20,9 +19,7 @@ class IterableObjectTest extends TestCase
         $this->assertEquals(2, $iterable_object->b);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function item_in_iterable_object_can_be_referenced_as_array_element()
     {
         $iterable_object = new IterableObject([
@@ -34,9 +31,7 @@ class IterableObjectTest extends TestCase
         $this->assertEquals(2, $iterable_object['b']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function item_in_iterable_object_can_be_referenced_as_collection_element()
     {
         $iterable_object = new IterableObject([
@@ -48,9 +43,7 @@ class IterableObjectTest extends TestCase
         $this->assertEquals(2, $iterable_object->get('b'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function iterable_object_can_be_iterated_over_like_a_collection()
     {
         $array = [
@@ -64,9 +57,7 @@ class IterableObjectTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function arrays_can_be_made_iterable_objects_when_adding_to_an_iterable_object()
     {
         $iterable_object = new IterableObject([
@@ -79,9 +70,7 @@ class IterableObjectTest extends TestCase
         $this->assertEquals(3, $iterable_object->b->c);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collections_can_be_made_iterable_objects_when_adding_to_an_iterable_object()
     {
         $iterable_object = new IterableObject([
@@ -94,9 +83,7 @@ class IterableObjectTest extends TestCase
         $this->assertEquals(3, $iterable_object->b->c);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function non_arrayable_items_are_not_changed_when_adding_with_makeIterable()
     {
         $iterable_object = new IterableObject([
@@ -108,9 +95,7 @@ class IterableObjectTest extends TestCase
         $this->assertIsString($iterable_object->b);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function objects_that_extend_IterableObject_are_not_changed_when_adding_with_makeIterable()
     {
         $iterable_object = new IterableObject([
@@ -124,9 +109,7 @@ class IterableObjectTest extends TestCase
         $this->assertTrue($iterable_object->b instanceof IterableObject);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function item_can_be_added_to_iterable_object_with_dot_notation()
     {
         $iterable_object = new IterableObject([
@@ -138,9 +121,7 @@ class IterableObjectTest extends TestCase
         $this->assertEquals(3, $iterable_object->b['c']['d']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nested_items_added_with_dot_notation_are_themselves_made_iterable()
     {
         $iterable_object = new IterableObject([
@@ -155,9 +136,7 @@ class IterableObjectTest extends TestCase
         $this->assertIsInt($iterable_object->b->c->d);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function intermediate_items_that_extend_IterableObject_are_not_changed_when_adding_new_items_with_dot_notation()
     {
         $iterable_object = new IterableObject([

--- a/tests/JigsawMacroTest.php
+++ b/tests/JigsawMacroTest.php
@@ -2,13 +2,12 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\Jigsaw;
 
 class JigsawMacroTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function jigsaw_macro_function_calls_successfully()
     {
         Jigsaw::macro('getNameMacro', function () {
@@ -18,9 +17,7 @@ class JigsawMacroTest extends TestCase
         $this->assertSame('Reed', Jigsaw::getNameMacro());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function jigsaw_mixin_function_calls_successfully()
     {
         Jigsaw::mixin(new JigsawMixinTestClass);

--- a/tests/MarkdownExtraTest.php
+++ b/tests/MarkdownExtraTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class MarkdownExtraTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function parse_markdown_inside_html_blocks()
     {
         $files = $this->setupSource([
@@ -23,9 +23,7 @@ class MarkdownExtraTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_specify_id_in_markdown()
     {
         $files = $this->setupSource([
@@ -42,9 +40,7 @@ class MarkdownExtraTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_specify_internal_anchor_links_in_markdown()
     {
         $files = $this->setupSource([
@@ -61,9 +57,7 @@ class MarkdownExtraTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_specify_class_name_in_markdown()
     {
         $files = $this->setupSource([
@@ -80,9 +74,7 @@ class MarkdownExtraTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function correctly_parse_single_line_html_markup_in_markdown_file()
     {
         $files = $this->setupSource([

--- a/tests/PageDataBindingTest.php
+++ b/tests/PageDataBindingTest.php
@@ -5,11 +5,12 @@ namespace Tests;
 use Illuminate\Container\Container;
 use Illuminate\Support\Str;
 use Illuminate\View\Component;
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\PageData;
 
 class PageDataBindingTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function can_bind_data_for_current_page_into_container()
     {
         class_alias('Tests\TestPageHeaderComponent', 'Components\PageHeader');

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class PaginationTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function blade_template_file_can_be_paginated()
     {
         $config = collect(['collections' => ['posts' => []]]);
@@ -49,9 +49,7 @@ class PaginationTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function blade_markdown_template_file_can_be_paginated()
     {
         $config = collect(['collections' => ['posts' => []]]);
@@ -94,9 +92,7 @@ class PaginationTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function blade_template_file_pagination_perPage_setting_defaults_to_config_global_setting()
     {
         $config = collect(['perPage' => 2, 'collections' => ['posts' => []]]);
@@ -138,9 +134,7 @@ class PaginationTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function blade_template_file_pagination_perPage_setting_defaults_to_config_collection_setting()
     {
         $config = collect(['collections' => ['posts' => ['perPage' => 2]]]);
@@ -182,9 +176,7 @@ class PaginationTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function blade_template_file_pagination_perPage_setting_defaults_to_config_collection_setting_when_config_global_setting_exists()
     {
         $config = collect(['perPage' => 10, 'collections' => ['posts' => ['perPage' => 2]]]);
@@ -226,9 +218,7 @@ class PaginationTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function blade_template_file_pagination_perPage_setting_overrides_config_global_setting()
     {
         $config = collect(['perPage' => 10, 'collections' => ['posts' => []]]);
@@ -271,9 +261,7 @@ class PaginationTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function blade_template_file_pagination_perPage_setting_overrides_config_collection_setting()
     {
         $config = collect(['collections' => ['posts' => ['perPage' => 10]]]);
@@ -316,9 +304,7 @@ class PaginationTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function blade_template_file_pagination_perPage_setting_overrides_config_collection_and_global_settings()
     {
         $config = collect(['perPage' => 20, 'collections' => ['posts' => ['perPage' => 10]]]);
@@ -361,7 +347,7 @@ class PaginationTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function blade_template_file_can_be_paginated_with_prefix()
     {
         $config = collect(['collections' => ['posts' => []]]);
@@ -397,7 +383,7 @@ class PaginationTest extends TestCase
         $this->assertFileMissing($this->tmpPath('build/blog/3/index.html'));
     }
 
-    /** @test */
+    #[Test]
     public function blade_markdown_template_file_can_be_paginated_with_prefix()
     {
         $config = collect(['collections' => ['posts' => []]]);

--- a/tests/PermalinkTest.php
+++ b/tests/PermalinkTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class PermalinkTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function markdown_file_with_permalink_is_built_at_permalink_destination_when_pretty_urls_is_off()
     {
         $yaml_header = implode("\n", ['---', 'permalink: permalink.html', 'extends: _layouts.master', 'section: content', '---']);
@@ -22,9 +22,7 @@ class PermalinkTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function markdown_file_with_permalink_is_built_at_permalink_destination_when_pretty_urls_is_on()
     {
         $yaml_header = implode("\n", ['---', 'permalink: permalink.html', 'extends: _layouts.master', 'section: content', '---']);
@@ -40,9 +38,7 @@ class PermalinkTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function markdown_file_with_nested_permalink_is_built_at_permalink_destination()
     {
         $yaml_header = implode("\n", ['---', 'permalink: nested/permalink.html', 'extends: _layouts.master', 'section: content', '---']);
@@ -58,9 +54,7 @@ class PermalinkTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function markdown_file_with_nested_permalink_is_built_at_permalink_destination_when_pretty_urls_is_on()
     {
         $yaml_header = implode("\n", ['---', 'permalink: nested/permalink.html', 'extends: _layouts.master', 'section: content', '---']);
@@ -76,9 +70,7 @@ class PermalinkTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function permalink_can_contain_leading_slash()
     {
         $yaml_header = implode("\n", ['---', 'permalink: /permalink.html', 'extends: _layouts.master', 'section: content', '---']);
@@ -94,9 +86,7 @@ class PermalinkTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function permalink_in_output_paths_contains_leading_slash_if_included_in_permalink()
     {
         $yaml_header = implode("\n", ['---', 'permalink: /permalink.html', 'extends: _layouts.master', 'section: content', '---']);
@@ -109,9 +99,7 @@ class PermalinkTest extends TestCase
         $this->assertEquals('/permalink.html', $jigsaw->getOutputPaths()[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function permalink_in_output_paths_contains_leading_slash_if_not_included_in_permalink()
     {
         $yaml_header = implode("\n", ['---', 'permalink: permalink.html', 'extends: _layouts.master', 'section: content', '---']);

--- a/tests/PhpOpenTagInMarkdownTest.php
+++ b/tests/PhpOpenTagInMarkdownTest.php
@@ -2,15 +2,14 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\Handlers\MarkdownHandler;
 use TightenCo\Jigsaw\IterableObject;
 use TightenCo\Jigsaw\PageData;
 
 class PhpOpenTagInMarkdownTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function md_files_containing_php_open_tag_are_processed()
     {
         $inputFile = $this->getInputFile('php-tag/php-tag-markdown.md');
@@ -23,9 +22,7 @@ class PhpOpenTagInMarkdownTest extends TestCase
         $this->assertStringContainsString('<code>&lt;?php', $outputFile[0]->contents());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function blade_md_hybrid_files_containing_php_open_tag_are_processed()
     {
         $inputFile = $this->getInputFile('php-tag/php-tag-blade-markdown.blade.md');

--- a/tests/PresetScaffoldBuilderTest.php
+++ b/tests/PresetScaffoldBuilderTest.php
@@ -4,6 +4,8 @@ namespace Tests;
 
 use Exception;
 use Mockery;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\Scaffold\CustomInstaller;
 use TightenCo\Jigsaw\Scaffold\DefaultInstaller;
 use TightenCo\Jigsaw\Scaffold\PresetPackage;
@@ -12,9 +14,7 @@ use TightenCo\Jigsaw\Scaffold\ProcessRunner;
 
 class PresetScaffoldBuilderTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function named_preset_resolves_to_predefined_package_path()
     {
         $preset = $this->app->make(PresetScaffoldBuilder::class);
@@ -37,9 +37,7 @@ class PresetScaffoldBuilderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function named_preset_resolves_to_vendor_package_path_if_not_predefined()
     {
         $preset = $this->app->make(PresetScaffoldBuilder::class);
@@ -59,10 +57,8 @@ class PresetScaffoldBuilderTest extends TestCase
         $this->assertEquals($this->tmp . $this->fixDirectorySlashes('/vendor/test/package'), $preset->package->path);
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function package_is_loaded_via_composer_if_not_found_locally()
     {
         $process = Mockery::spy(ProcessRunner::class);
@@ -76,9 +72,7 @@ class PresetScaffoldBuilderTest extends TestCase
         $process->shouldHaveReceived('run')->with('composer require test/other-package');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function exception_is_thrown_if_package_is_missing_a_slash()
     {
         $preset = $this->app->make(PresetScaffoldBuilder::class);
@@ -96,9 +90,7 @@ class PresetScaffoldBuilderTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function exception_is_thrown_if_package_init_file_contains_errors()
     {
         $preset = $this->app->make(PresetScaffoldBuilder::class);
@@ -124,10 +116,8 @@ class PresetScaffoldBuilderTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function init_file_of_array_type_is_loaded()
     {
         $default_installer = Mockery::spy(DefaultInstaller::class);
@@ -155,10 +145,8 @@ class PresetScaffoldBuilderTest extends TestCase
             ->with($preset, ['delete' => ['test.json']]);
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function init_file_of_php_type_is_loaded()
     {
         $custom_installer = Mockery::spy(CustomInstaller::class);
@@ -189,10 +177,8 @@ class PresetScaffoldBuilderTest extends TestCase
         $custom_installer->shouldHaveReceived('copy')->with('test');
     }
 
-    /**
-     * @test
-     * @doesNotPerformAssertions
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function init_file_is_optional()
     {
         $default_installer = Mockery::spy(DefaultInstaller::class);
@@ -214,9 +200,7 @@ class PresetScaffoldBuilderTest extends TestCase
         $default_installer->shouldHaveReceived('install')->with($preset, []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function jigsaw_package_dependency_is_restored_to_fresh_composer_dot_json_when_archiving_site()
     {
         $old_composer = [
@@ -250,9 +234,7 @@ class PresetScaffoldBuilderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function jigsaw__package_dependency_is_restored_to_fresh_composer_dot_json_when_deleting_site()
     {
         $old_composer = [

--- a/tests/RemoteCollectionsTest.php
+++ b/tests/RemoteCollectionsTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class RemoteCollectionsTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_does_not_require_matching_source_directory()
     {
         $config = collect([
@@ -20,9 +20,7 @@ class RemoteCollectionsTest extends TestCase
         $this->assertCount(0, $siteData->collection_without_directory);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collection_items_are_created_from_files_in_a_collection_directory()
     {
         $config = collect([
@@ -49,7 +47,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function collection_items_without_matching_handler_are_ignored()
     {
         $config = collect(['collections' => ['collection' => []]]);
@@ -66,9 +64,7 @@ class RemoteCollectionsTest extends TestCase
         $this->assertCount(1, $siteData->collection);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function output_files_are_built_from_files_in_a_collection_directory()
     {
         $config = collect([
@@ -99,9 +95,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function output_files_are_built_from_items_key_in_config()
     {
         $config = collect([
@@ -130,9 +124,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function output_files_are_built_from_items_key_in_config_and_from_files_in_collection_directory()
     {
         $config = collect([
@@ -170,9 +162,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function temporary_directory_for_remote_items_is_removed_after_build_is_complete()
     {
         $config = collect([
@@ -197,9 +187,7 @@ class RemoteCollectionsTest extends TestCase
         $this->assertFileMissing($this->tmpPath('source/_test/_tmp'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function temporary_parent_directory_for_remote_items_is_removed_if_empty_after_build_is_complete()
     {
         $config = collect([
@@ -224,9 +212,7 @@ class RemoteCollectionsTest extends TestCase
         $this->assertFileMissing($this->tmpPath('source/_test'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function items_key_in_config_can_return_an_illuminate_collection()
     {
         $config = collect([
@@ -255,9 +241,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function value_of_content_key_in_item_array_is_parsed_as_markdown()
     {
         $config = collect([
@@ -285,9 +269,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function page_variables_are_created_from_keys_in_item_array()
     {
         $config = collect([
@@ -316,9 +298,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function page_variables_are_optional_in_item_array()
     {
         $config = collect([
@@ -346,9 +326,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function value_of_string_item_is_parsed_as_markdown_content()
     {
         $config = collect([
@@ -372,9 +350,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function strings_and_arrays_can_be_mixed_in_items_key_in_config()
     {
         $config = collect([
@@ -408,9 +384,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function filename_for_output_file_is_set_to_collection_name_plus_index_if_not_specified()
     {
         $config = collect([
@@ -439,9 +413,7 @@ class RemoteCollectionsTest extends TestCase
         $this->assertTrue($files->hasChild('build/test/test-2.html'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function filename_for_output_file_is_set_to_collection_name_plus_array_key_if_filename_not_specified_and_key_is_string()
     {
         $config = collect([
@@ -470,9 +442,7 @@ class RemoteCollectionsTest extends TestCase
         $this->assertTrue($files->hasChild('build/test/bar.html'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function filename_for_output_file_is_set_to_filename_key_if_specified()
     {
         $config = collect([
@@ -498,9 +468,7 @@ class RemoteCollectionsTest extends TestCase
         $this->assertTrue($files->hasChild('build/test/custom-filename.html'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function items_key_in_config_can_be_a_function_that_returns_an_array()
     {
         $config = collect([
@@ -533,9 +501,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function items_function_can_access_other_config_variables()
     {
         $config = collect([
@@ -564,9 +530,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function items_key_in_config_can_be_a_function_that_returns_a_collection()
     {
         $config = collect([
@@ -599,9 +563,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function items_key_in_config_can_fetch_content_from_a_remote_api()
     {
         $config = collect([
@@ -632,9 +594,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function blade_directives_in_remote_content_get_parsed()
     {
         $config = collect([
@@ -658,9 +618,7 @@ class RemoteCollectionsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collections_key_in_config_can_be_a_function_that_returns_a_list_of_collections()
     {
         $config = collect([

--- a/tests/ScaffoldTest.php
+++ b/tests/ScaffoldTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\Scaffold\BasicScaffoldBuilder;
 
 class ScaffoldTest extends TestCase
@@ -19,9 +20,7 @@ class ScaffoldTest extends TestCase
         'yarn.lock' => '',
     ];
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_archive_existing_files_and_directories()
     {
         $this->createSource(array_merge(
@@ -39,9 +38,7 @@ class ScaffoldTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function will_create_archived_directory_if_none_exists_when_archiving_site()
     {
         $this->createSource(self::EXISTING_FILES);
@@ -56,9 +53,7 @@ class ScaffoldTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function will_erase_contents_of_archived_directory_if_it_already_exists_when_archiving_site()
     {
         $this->createSource(array_merge(
@@ -75,9 +70,7 @@ class ScaffoldTest extends TestCase
         $this->assertFileMissing($this->tmpPath('archived/old-file.md'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function will_ignore_archived_directory_when_archiving_site()
     {
         $this->createSource(array_merge(
@@ -92,9 +85,7 @@ class ScaffoldTest extends TestCase
         $this->assertFileMissing($this->tmpPath('archived/archived'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function will_ignore_vendor_directory_when_archiving_site()
     {
         $this->createSource(array_merge(
@@ -109,9 +100,7 @@ class ScaffoldTest extends TestCase
         $this->assertFileMissing($this->tmpPath('archived/vendor'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function will_ignore_node_modules_directory_when_archiving_site()
     {
         $this->createSource(array_merge(
@@ -126,9 +115,7 @@ class ScaffoldTest extends TestCase
         $this->assertFileMissing($this->tmpPath('archived/node_modules'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_delete_existing_files_and_directories()
     {
         $this->createSource(self::EXISTING_FILES);
@@ -141,9 +128,7 @@ class ScaffoldTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function will_ignore_archived_directory_when_deleting_site()
     {
         $this->createSource(array_merge(
@@ -157,9 +142,7 @@ class ScaffoldTest extends TestCase
         $this->assertFileExists($this->tmpPath('archived'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function will_ignore_vendor_directory_when_deleting_site()
     {
         $this->createSource(array_merge(
@@ -173,9 +156,7 @@ class ScaffoldTest extends TestCase
         $this->assertFileExists($this->tmpPath('vendor'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function will_ignore_node_modules_directory_when_deleting_site()
     {
         $this->createSource(array_merge(
@@ -189,9 +170,7 @@ class ScaffoldTest extends TestCase
         $this->assertFileExists($this->tmpPath('node_modules'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function jigsaw_dependency_is_restored_to_fresh_composer_dot_json_when_archiving_site()
     {
         $old_composer = ['require' => ['tightenco/jigsaw' => '^1.2']];
@@ -204,9 +183,7 @@ class ScaffoldTest extends TestCase
         $this->assertEquals($old_composer, json_decode(file_get_contents($this->tmpPath('composer.json')), true));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function composer_dot_json_is_not_restored_if_it_did_not_exist_when_archiving_site()
     {
         $this->createSource(self::EXISTING_FILES);
@@ -217,9 +194,7 @@ class ScaffoldTest extends TestCase
         $this->assertFileMissing($this->tmpPath('composer.json'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function jigsaw_dependency_is_restored_to_fresh_composer_dot_json_when_deleting_site()
     {
         $old_composer = ['require' => ['tightenco/jigsaw' => '^1.2']];
@@ -232,9 +207,7 @@ class ScaffoldTest extends TestCase
         $this->assertEquals($old_composer, json_decode(file_get_contents($this->tmpPath('composer.json')), true));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function composer_dot_json_is_not_restored_if_it_did_not_exist_when_deleting_site()
     {
         $this->createSource(self::EXISTING_FILES);

--- a/tests/SiteBuilderTest.php
+++ b/tests/SiteBuilderTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class SiteBuilderTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function destination_directory_is_deleted_when_building_site()
     {
         $this->createSource([
@@ -23,9 +23,7 @@ class SiteBuilderTest extends TestCase
         $this->assertCount(1, app('files')->filesAndDirectories($this->tmpPath('build')));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function existing_files_in_destination_directory_are_replaced_when_building_site()
     {
         $this->createSource([
@@ -43,9 +41,7 @@ class SiteBuilderTest extends TestCase
         $this->assertOutputFile('build/test.html', 'New file');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function page_metadata_contains_path()
     {
         $files = $this->setupSource(['nested' => ['page.blade.php' => '{{ $page->getPath() }}']]);
@@ -57,9 +53,7 @@ class SiteBuilderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function page_metadata_contains_relative_path()
     {
         $files = $this->setupSource(['nested' => ['page.blade.php' => '{{ $page->getRelativePath() }}']]);
@@ -71,9 +65,7 @@ class SiteBuilderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function page_metadata_contains_url()
     {
         $config = collect(['baseUrl' => 'foo.com']);
@@ -87,9 +79,7 @@ class SiteBuilderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function page_metadata_contains_source_file_name()
     {
         $files = $this->setupSource(['page.blade.php' => '{{ $page->getFilename() }}']);
@@ -101,9 +91,7 @@ class SiteBuilderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function page_metadata_contains_source_file_extension()
     {
         $files = $this->setupSource(['page.blade.php' => '{{ $page->getExtension() }}']);
@@ -115,9 +103,7 @@ class SiteBuilderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function page_metadata_contains_source_file_modified_time()
     {
         $files = $this->setupSource(['page.blade.php' => '{{ $page->getModifiedTime() }}']);
@@ -129,9 +115,7 @@ class SiteBuilderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_get_output_paths_after_building_site()
     {
         $files = $this->setupSource([
@@ -151,9 +135,7 @@ class SiteBuilderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_get_collection_of_page_info_after_building_site()
     {
         $files = $this->setupSource([

--- a/tests/SnapshotsTest.php
+++ b/tests/SnapshotsTest.php
@@ -46,7 +46,7 @@ class SnapshotsTest extends PHPUnit
     public function build(string $name)
     {
         // Delete the contents of the output directory in the source to clean up previous builds
-        $this->filesystem->deleteDirectory($this->output($name), true);
+        $this->filesystem->deleteDirectory($this->testOutput($name), true);
 
         $jigsaw = realpath(implode('/', array_filter([__DIR__, '..', 'jigsaw'])));
         $arguments = static::$arguments[$name] ?? [];
@@ -63,19 +63,19 @@ class SnapshotsTest extends PHPUnit
 
     private function assertSnapshotMatches($name)
     {
-        $this->assertDirectoryExists($this->output($name));
+        $this->assertDirectoryExists($this->testOutput($name));
 
         $this->assertSame(
             collect($this->filesystem->allFiles($this->snapshot($name), true))
                 ->map(fn ($file) => Str::after($file->getPathname(), $this->snapshot($name)))
                 ->toArray(),
-            collect($this->filesystem->allFiles($this->output($name), true))
-                ->map(fn ($file) => Str::after($file->getPathname(), $this->output($name)))
+            collect($this->filesystem->allFiles($this->testOutput($name), true))
+                ->map(fn ($file) => Str::after($file->getPathname(), $this->testOutput($name)))
                 ->toArray(),
             "Output file structure does not match snapshot in '{$name}'.",
         );
 
-        collect($this->filesystem->allFiles($this->output($name), true))->map(function (SplFileInfo $file) use ($name) {
+        collect($this->filesystem->allFiles($this->testOutput($name), true))->map(function (SplFileInfo $file) use ($name) {
             $this->assertSame(
                 file_get_contents(implode(DIRECTORY_SEPARATOR, array_filter([$this->snapshot($name), $file->getRelativePathname()]))),
                 $file->getContents(),
@@ -89,7 +89,7 @@ class SnapshotsTest extends PHPUnit
         return implode(DIRECTORY_SEPARATOR, array_filter([__DIR__, 'snapshots', $name]));
     }
 
-    private function output(string $name): string
+    private function testOutput(string $name): string
     {
         $output = $name === 'environment-specific-config-file' ? 'build_staging' : 'build_local';
 

--- a/tests/SnapshotsTest.php
+++ b/tests/SnapshotsTest.php
@@ -4,6 +4,9 @@ namespace Tests;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase as PHPUnit;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Exception\ProcessFailedException;
@@ -25,9 +28,9 @@ class SnapshotsTest extends PHPUnit
         $this->filesystem = new Filesystem;
     }
 
-    public function snapshots(): array
+    public static function snapshots(): array
     {
-        return collect((new Filesystem)->directories($this->source()))
+        return collect((new Filesystem())->directories(static::source()))
             ->map(fn ($path) => basename($path))
             ->reject(fn ($name) => Str::endsWith($name, '_snapshot'))
             // Prepend the test command with JIGSAW_SNAPSHOTS=<snapshot-names> to run specific snapshot tests
@@ -38,11 +41,9 @@ class SnapshotsTest extends PHPUnit
             ->all();
     }
 
-    /**
-     * @test
-     * @group snapshots
-     * @dataProvider snapshots
-     */
+    #[Test]
+    #[Group('snapshots')]
+    #[DataProvider('snapshots')]
     public function build(string $name)
     {
         // Delete the contents of the output directory in the source to clean up previous builds
@@ -51,7 +52,7 @@ class SnapshotsTest extends PHPUnit
         $jigsaw = realpath(implode('/', array_filter([__DIR__, '..', 'jigsaw'])));
         $arguments = static::$arguments[$name] ?? [];
 
-        $build = new Process(array_merge(['php', $jigsaw, 'build'], $arguments, ['-vvv']), $this->source($name));
+        $build = new Process(array_merge(['php', $jigsaw, 'build'], $arguments, ['-vvv']), static::source($name));
         $build->run();
 
         if (! $build->isSuccessful()) {
@@ -84,7 +85,7 @@ class SnapshotsTest extends PHPUnit
         });
     }
 
-    private function source(string $name = ''): string
+    private static function source(string $name = ''): string
     {
         return implode(DIRECTORY_SEPARATOR, array_filter([__DIR__, 'snapshots', $name]));
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,9 +26,9 @@ class TestCase extends PHPUnit
     protected Filesystem $filesystem;
     protected string $tmp;
 
-    public function __construct()
+    public function __construct($name = null, array $data = [], $dataName = '') 
     {
-        parent::__construct("Jigsaw");
+        parent::__construct($name, $data, $dataName);
 
         $this->filesystem = new Filesystem;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -79,12 +79,12 @@ class TestCase extends PHPUnit
             Component::forgetFactory();
         }
 
-        HandleExceptions::forgetApp();
-
-        if (! $this->hasFailed()) {
+        if ($this->status()->isSuccess()) {
             $this->filesystem->deleteDirectories(__DIR__ . '/fixtures/tmp/');
             $this->filesystem->deleteDirectory(app()->cachePath());
         }
+
+        HandleExceptions::flushState();
 
         parent::tearDown();
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,7 +28,7 @@ class TestCase extends PHPUnit
 
     public function __construct()
     {
-        parent::__construct();
+        parent::__construct("Jigsaw");
 
         $this->filesystem = new Filesystem;
     }

--- a/tests/TestCaseTest.php
+++ b/tests/TestCaseTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class TestCaseTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function create_test_file_structure_from_nested_array()
     {
         $this->createSource([
@@ -41,7 +43,7 @@ class TestCaseTest extends TestCase
         $this->assertStringEqualsFile($this->tmpPath('resources/js/main.js'), 'console.log("Look ma, no file system!");');
     }
 
-    /** @test */
+    #[Test]
     public function create_test_files_with_multiple_extensions()
     {
         $this->createSource([

--- a/tests/ViewPathTest.php
+++ b/tests/ViewPathTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class ViewPathTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function can_load_views_from_custom_path()
     {
         $this->createSource([

--- a/tests/ViewRendererTest.php
+++ b/tests/ViewRendererTest.php
@@ -5,13 +5,14 @@ namespace Tests;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Factory;
 use Mockery;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\View\ViewRenderer;
 
 class ViewRendererTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
+    #[DoesNotPerformAssertions]
     public function it_registers_view_hint_paths()
     {
         $mock = Mockery::mock(Factory::class);
@@ -29,9 +30,7 @@ class ViewRendererTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_register_view_hint_paths_if_not_specified_in_config()
     {
         $mock = Mockery::mock(Factory::class);
@@ -45,9 +44,7 @@ class ViewRendererTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_register_view_hint_paths_if_empty_in_config()
     {
         $mock = Mockery::mock(Factory::class);

--- a/tests/snapshots/default/source/escape-test-hybrid.blade.md
+++ b/tests/snapshots/default/source/escape-test-hybrid.blade.md
@@ -15,7 +15,7 @@ Can we have php opening tags here?
 @endverbatim
 
 ```
-<?{{ '' }}php
+<?php
 ```
 
 <hr>
@@ -34,9 +34,7 @@ This works: <?php{{ '' }}
 This works: {!! $page->php !!}
 This works: {!! '<' . '?php' !!}
 This works: <{{ '?php' }}
-This works: <?php{{ '' }}
-This works: <?{{ '' }}php
-This works: <?.php
+This works: <?php
 
 // Test comment...
 

--- a/tests/snapshots/default_snapshot/escape-test-hybrid/index.html
+++ b/tests/snapshots/default_snapshot/escape-test-hybrid/index.html
@@ -128,8 +128,6 @@ This works: &lt;?php
 This works: &lt;?php
 This works: &lt;?php
 This works: &lt;?php
-This works: &lt;?php
-This works: &lt;?.php
 
 // Test comment...
 


### PR DESCRIPTION
This PR upgrades the following key dependencies:
- Illuminate components to v11
- PHPUnit to v11

In the process, this required upgrades two Markdown-related dependencies:
- [michelf/php-markdown](https://github.com/michelf/php-markdown) to v2, for PHPUnit compatibility
- [mnapoli/front-yaml](https://github.com/mnapoli/FrontYAML) to v2, for Symfony compatibility

The `front-yaml` upgrade adds a `string` return type declaration to the `parse` method; since modifying Jigsaw's markdown parser isn't documented (other than using the `commonmark` alternative as mentioned in https://github.com/tighten/jigsaw/pull/687, which should be unaffected), I don't think we need to consider this a breaking change.

(This PR builds on https://github.com/tighten/jigsaw/pull/701, from @njames, focusing solely on bumping underlying dependencies to Illuminate v11 components, without the CS fixes and the addition of Laravel Prompts. It supersedes https://github.com/tighten/jigsaw/pull/677.)
