### PR TITLE
CommonMark Renderer

### DIFF
--- a/src/Parsers/CommonMarkParser.php
+++ b/src/Parsers/CommonMarkParser.php
@@ -28,6 +28,10 @@ class CommonMarkParser implements MarkdownParserContract
             new TableExtension,
         ]))->map(fn ($extension) => $environment->addExtension($extension));
 
+        collect(
+            Arr::get(app('config'), 'commonmark.renderers')
+        )->map(fn ($renderer, $nodeClass) => $environment->addRenderer($nodeClass, $renderer));
+
         $this->converter = new MarkdownConverter($environment);
     }
 


### PR DESCRIPTION
Allows renderers to be defined in the `config.php` file, which are then passed to the `league/commonmark` package.

This means packages like [spatie/commonmark-highlighter](https://github.com/spatie/commonmark-highlighter) can be used.

```php
// config.php Example
<?php

return [
    'production' => false,
    'baseUrl' => '',
    'title' => 'Jigsaw',
    'description' => 'Website description.',
    'collections' => [],
    'commonmark' => [
        'renderers' => [
            \League\CommonMark\Extension\CommonMark\Node\Block\FencedCode::class => new \Spatie\CommonMarkHighlighter\FencedCodeRenderer,
            \League\CommonMark\Extension\CommonMark\Node\Block\IndentedCode::class => new \Spatie\CommonMarkHighlighter\IndentedCodeRenderer,
        ],
    ],
];
```