### PR TITLE
Fix Format Action for Forked Repos

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,6 +10,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.1


### PR DESCRIPTION
Addresses an issue with the `format.yml` GitHub Action workflow where it fails for pull requests from forked repositories. It adds the `repository` parameter, ensuring the correct branch from the fork is checked out.

Without this PRs fail checks with: A branch or tag with the name 'xyz-etc' could not be found