### PR TITLE
Fix dynamic components

### DIFF
--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace TightenCo\Jigsaw\Providers;
 
-use Illuminate\View\DynamicComponent;
 use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Engines\FileEngine;
@@ -16,6 +15,7 @@ use TightenCo\Jigsaw\Parsers\FrontMatterParser;
 use TightenCo\Jigsaw\Support\ServiceProvider;
 use TightenCo\Jigsaw\View\BladeCompiler;
 use TightenCo\Jigsaw\View\BladeMarkdownEngine;
+use TightenCo\Jigsaw\View\DynamicComponent;
 use TightenCo\Jigsaw\View\MarkdownEngine;
 use TightenCo\Jigsaw\View\ViewRenderer;
 

--- a/src/View/DynamicComponent.php
+++ b/src/View/DynamicComponent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace TightenCo\Jigsaw\View;
+
+use Illuminate\Container\Container;
+use Illuminate\View\DynamicComponent as BaseDynamnicComponent;
+
+class DynamicComponent extends BaseDynamnicComponent
+{
+    protected function compiler()
+    {
+        if (! static::$compiler) {
+            static::$compiler = new ComponentTagCompiler(
+                Container::getInstance()->make('blade.compiler')->getClassComponentAliases(),
+                Container::getInstance()->make('blade.compiler')->getClassComponentNamespaces(),
+                Container::getInstance()->make('blade.compiler')
+            );
+        }
+
+        return static::$compiler;
+    }
+}

--- a/tests/snapshots/dynamic-component/source/_components/alert.blade.php
+++ b/tests/snapshots/dynamic-component/source/_components/alert.blade.php
@@ -1,0 +1,7 @@
+<div class="alert alert-danger">
+    <h3>This is the component</h3>
+    <h4>Named title slot: {{ $title }}</h4>
+    <hr>
+        {{ $slot }}
+    <hr>
+</div>

--- a/tests/snapshots/dynamic-component/source/index.blade.php
+++ b/tests/snapshots/dynamic-component/source/index.blade.php
@@ -1,0 +1,6 @@
+@php
+    $dynamic = 'alert';
+@endphp
+<x-dynamic-component :component="$dynamic" title="Title">
+    Slot
+</x-dynamic-component>

--- a/tests/snapshots/dynamic-component_snapshot/index.html
+++ b/tests/snapshots/dynamic-component_snapshot/index.html
@@ -1,0 +1,7 @@
+<div class="alert alert-danger">
+    <h3>This is the component</h3>
+    <h4>Named title slot: Title</h4>
+    <hr>
+        Slot
+    <hr>
+</div>


### PR DESCRIPTION
Fixes `<x-dynamic-component>` Blade components, which don't work but should have been supported (and might have worked at some point in the past).

All this does is override the `DynamicComponent` component class so that it uses Jigsaw's customized `ComponentTagCompiler` instead of Laravel's. I didn't even change anything in `DynamicComponent`, just the fact that we redeclare it picks up the new compiler because of the namespace it's in.

There might be more nuance to explore here, this is super basic and just makes the happy path example in the included snapshot test work as expected.

Closes #707.