### PR TITLE
Adds watch option to build command

### DIFF
--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -102,8 +102,11 @@ class BuildCommand extends Command
                         $files[$file->getPathname()] = $file->getMTime();
                     }
                 }
-            } catch (Exception $e) {
-                $this->consoleOutput->writeln('<error>Error scanning directory: ' . $e->getMessage() . '</error>');
+            } catch (Throwable $e) {
+                $this->app->make(ExceptionHandler::class)->report($e);
+                $this->app->make(ExceptionHandler::class)->renderForConsole($this->consoleOutput, $e);
+
+                return static::FAILURE;
             }
             return $files;
         };

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -115,19 +115,24 @@ class BuildCommand extends Command
         while (true) {
             try {
                 $currentTimestamps = $scanFiles($sourcePath);
+                $affectedFiles = 0;
 
                 foreach ($currentTimestamps as $file => $mtime) {
                     if (!isset($fileTimestamps[$file]) || $fileTimestamps[$file] !== $mtime) {
-                        $this->build();
-                        break;
+                        $affectedFiles++;
+                        $this->consoleOutput->writeln('<info>File changed: ' . $file . '</info>');
                     }
                 }
 
                 foreach ($fileTimestamps as $file => $mtime) {
                     if (!isset($currentTimestamps[$file])) {
-                        $this->build();
-                        break;
+                        $affectedFiles++;
+                        $this->consoleOutput->writeln('<info>File deleted: ' . $file . '</info>');
                     }
+                }
+
+                if ($affectedFiles > 0) {
+                    $this->build();
                 }
 
                 $fileTimestamps = $currentTimestamps;

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -33,8 +33,8 @@ class BuildCommand extends Command
             ->setDescription('Build your site.')
             ->addArgument('env', InputArgument::OPTIONAL, 'What environment should we use to build?', 'local')
             ->addOption('pretty', null, InputOption::VALUE_REQUIRED, 'Should the site use pretty URLs?', 'true')
-            ->addOption('cache', 'c', InputOption::VALUE_OPTIONAL, 'Should a cache be used when building the site?', 'false')
-            ->addOption('watch', 'w', InputOption::VALUE_NONE, 'Should watch for file changes and rebuild?');
+            ->addOption('watch', 'w', InputOption::VALUE_NONE, 'Should watch for file changes and rebuild?')
+            ->addOption('cache', 'c', InputOption::VALUE_OPTIONAL, 'Should a cache be used when building the site?', 'false');
     }
 
     protected function fire()


### PR DESCRIPTION
Proposal to add a native PHP file watcher to Jigsaw

```bash
vendor/bin/jigsaw build --watch
```

Useful for [minimal jigsaw templates](https://github.com/otonielguajardo/jigsaw-minimal-template) that don't need the asset bundling step and want to completely skip using npm

```bash
composer require tightenco/jigsaw
vendor/bin/jigsaw init otonielguajardo/jigsaw-minimal-template
vendor/bin/jigsaw build --watch
vendor/bin/jigsaw serve
```