### PR TITLE
chore: add new files to `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,11 @@
-/.editorconfig      export-ignore
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/phpunit.xml.dist   export-ignore
-/tests              export-ignore
+/.editorconfig           export-ignore
+/.git-blame-ignore-revs  export-ignore
+/.gitattributes          export-ignore
+/.github                 export-ignore
+/.gitignore              export-ignore
+/CONTRIBUTING.md         export-ignore
+/logo.png                export-ignore
+/jigsaw-banner.png       export-ignore
+/phpunit.xml             export-ignore
+/pint.json               export-ignore
+/tests                   export-ignore


### PR DESCRIPTION
This prevents unnecessary files being distributed to vendor installs. This will save about 100K on each install, which isn't much but it also means that these don't show up in IDE suggestions.