### PR TITLE
chore(deps): add support for `illuminate/collections:^12`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/collections": "^11.0",
+        "illuminate/collections": "^11.0 || ^12.0",
         "illuminate/console": "^11.0 || ^12.0",
         "illuminate/container": "^11.0 || ^12.0",
         "illuminate/filesystem": "^11.0 || ^12.0",


### PR DESCRIPTION
It looks like this update was missed as part of #724, which prevents Laravel 12 from being actually used.