### PR TITLE
Fix: Test failing on Windows due to missing path normalization: resolve_path_does_not_strip_0s

### DIFF
--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -42,7 +42,8 @@ class HelpersTest extends TestCase
     public function resolve_path_does_not_strip_0s()
     {
         $path = 'path/to/assets/0/0/0.png';
+        $normalizedOutput = str_replace(['/', '\\'], '/', resolvePath($path));
 
-        $this->assertSame($path, resolvePath($path));
+        $this->assertSame($path, $normalizedOutput);
     }
 }


### PR DESCRIPTION
Fix directory separator issue on Windows:
```
There was 1 failure:

1) Tests\HelpersTest::resolve_path_does_not_strip_0s
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'path/to/assets/0/0/0.png'
+'path\to\assets\0\0\0.png'
```
