### PR TITLE
Update Vite plugin version

### DIFF
--- a/stubs/site/package-lock.json
+++ b/stubs/site/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "jigsaw-site-b",
+    "name": "site",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "devDependencies": {
-                "@tighten/jigsaw-vite-plugin": "^1.0.0",
+                "@tighten/jigsaw-vite-plugin": "^1.0.1",
                 "autoprefixer": "^10.4.21",
                 "postcss": "^8.5.3",
                 "postcss-import": "^14.0.0",
@@ -936,9 +936,9 @@
             ]
         },
         "node_modules/@tighten/jigsaw-vite-plugin": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@tighten/jigsaw-vite-plugin/-/jigsaw-vite-plugin-1.0.0.tgz",
-            "integrity": "sha512-JRW/bKrTRsV9zi6pvTl/NcAUevaDC9RyCwbEPryGO/ggiWlCgsmCY5ZgFD62SvkaAhInQJsUTA9q0CaTgtdqpw==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@tighten/jigsaw-vite-plugin/-/jigsaw-vite-plugin-1.0.1.tgz",
+            "integrity": "sha512-6rb8JkDz2GEirftw+CqoIVmfCWViR45EFEoKaI+RoPU5hSqwkY8txl5GwFv27vgriYLVm9xC8laOf2b2p0+8rw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/stubs/site/package.json
+++ b/stubs/site/package.json
@@ -6,7 +6,7 @@
         "build": "vite build"
     },
     "devDependencies": {
-        "@tighten/jigsaw-vite-plugin": "^1.0.0",
+        "@tighten/jigsaw-vite-plugin": "^1.0.1",
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.3",
         "postcss-import": "^14.0.0",


### PR DESCRIPTION
This PR bumps the version of the Vite plugin to include a [recently merged bug fix](https://github.com/tighten/jigsaw-vite-plugin/pull/1).