### PR TITLE
Adds a snapshot case for the once directive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "michelf/php-markdown": "^2.0",
         "mnapoli/front-yaml": "^2.0",
         "nunomaduro/collision": "^8.1",
+        "ramsey/uuid": "^4.9",
         "spatie/laravel-ignition": "^2.4",
         "symfony/console": "^6.0 || ^7.0",
         "symfony/error-handler": "^6.0 || ^7.0",

--- a/tests/snapshots/blade-with-once/source/_components/alert.blade.php
+++ b/tests/snapshots/blade-with-once/source/_components/alert.blade.php
@@ -1,0 +1,9 @@
+<div>
+    {{ $slot }}
+</div>
+
+@once
+<script>
+    alert('This is the component')
+</script>
+@endonce

--- a/tests/snapshots/blade-with-once/source/_layouts/main.blade.php
+++ b/tests/snapshots/blade-with-once/source/_layouts/main.blade.php
@@ -1,0 +1,8 @@
+<div>
+    @yield('structured-markup')
+
+    <p>MAIN LAYOUT</p>
+    <div>
+        @yield('body')
+    </div>
+</div>

--- a/tests/snapshots/blade-with-once/source/index.blade.php
+++ b/tests/snapshots/blade-with-once/source/index.blade.php
@@ -1,0 +1,18 @@
+@extends('_layouts.main')
+
+@section('structured-markup')
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+        }
+    </script>
+@endsection
+
+@section('body')
+Hello world!
+
+<x-alert>Slot 1</x-alert>
+
+<x-alert>Slot 2</x-alert>
+@endsection

--- a/tests/snapshots/blade-with-once_snapshot/index.html
+++ b/tests/snapshots/blade-with-once_snapshot/index.html
@@ -1,0 +1,26 @@
+<div>
+        <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+        }
+    </script>
+
+    <p>MAIN LAYOUT</p>
+    <div>
+        Hello world!
+
+<div>
+    Slot 1
+</div>
+
+<script>
+    alert('This is the component')
+</script>
+
+<div>
+    Slot 2
+</div>
+
+    </div>
+</div>


### PR DESCRIPTION
## Changes
Ensures that we can use the `once` directive since under the hood the directive uses the `Str::uuid` which uses `ramsey/uuid` package 
- [compileOnce reference](https://github.com/gcavanunez/framework/blob/12.x/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php#L291)
