### PR TITLE
Keep the leading slash in pretty output path for index files

### DIFF
--- a/src/PathResolvers/PrettyOutputPathResolver.php
+++ b/src/PathResolvers/PrettyOutputPathResolver.php
@@ -11,7 +11,7 @@ class PrettyOutputPathResolver
                 return '/' . leftTrimPath(trimPath($path) . '/') . trimPath($prefix . '/' . $page) . '/';
             }
 
-            return '/' . leftTrimPath(trimPath($path) . '/') . '/';
+            return '/' . leftTrimPath(trimPath($path) . '/');
         }
 
         if ($type === 'html' && $name !== 'index') {

--- a/src/PathResolvers/PrettyOutputPathResolver.php
+++ b/src/PathResolvers/PrettyOutputPathResolver.php
@@ -11,7 +11,7 @@ class PrettyOutputPathResolver
                 return '/' . leftTrimPath(trimPath($path) . '/') . trimPath($prefix . '/' . $page) . '/';
             }
 
-            return leftTrimPath('/' . trimPath($path) . '/') . '/';
+            return '/' . leftTrimPath(trimPath($path) . '/') . '/';
         }
 
         if ($type === 'html' && $name !== 'index') {

--- a/tests/FilePathTest.php
+++ b/tests/FilePathTest.php
@@ -175,6 +175,30 @@ class FilePathTest extends TestCase
         $this->assertEquals('/اختبار_مسار_الملف', $outputPath[0]);
     }
 
+    public function test_index_file_at_root_has_leading_slash()
+    {
+        $resolver = new PrettyOutputPathResolver;
+        $this->assertEquals('/', $resolver->link('', 'index', 'html'));
+    }
+
+    public function test_index_file_in_subdirectory_has_leading_slash()
+    {
+        $resolver = new PrettyOutputPathResolver;
+        $this->assertEquals('/blog/', $resolver->link('blog', 'index', 'html'));
+    }
+
+    public function test_index_file_in_nested_subdirectory_has_leading_slash()
+    {
+        $resolver = new PrettyOutputPathResolver;
+        $this->assertEquals('/blog/posts/', $resolver->link('blog/posts', 'index', 'html'));
+    }
+
+    public function test_paginated_index_file_in_subdirectory_has_leading_slash()
+    {
+        $resolver = new PrettyOutputPathResolver;
+        $this->assertEquals('/blog/2/', $resolver->link('blog', 'index', 'html', 2));
+    }
+
     protected function getPageVariableDummy($filename)
     {
         return new PageVariable([

--- a/tests/snapshots/default-trailing-slash/source/about/index.blade.php
+++ b/tests/snapshots/default-trailing-slash/source/about/index.blade.php
@@ -1,0 +1,5 @@
+@extends('_layouts.master')
+
+@section('body')
+    <h2>About</h2>
+@endsection

--- a/tests/snapshots/default-trailing-slash_snapshot/about/index.html
+++ b/tests/snapshots/default-trailing-slash_snapshot/about/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
+    </head>
+    <body class="border-t-3 border-primary full-height">
+
+        <nav class="navbar navbar-brand">
+            <div class="container">
+                <div class="navbar-content">
+                    <div>
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
+                            <strong>Jigsaw Collections Demo</strong>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </nav>
+
+        <div class="container m-xs-b-6">
+            <div class="row">
+
+                <div class="col-xs-4">
+                    <nav class="nav-list">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
+        <icon></icon>Posts
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
+        <icon></icon>Pagination
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
+        <icon></icon>Categories
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw.test/people">
+        <icon></icon>People
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
+        <icon></icon>Variables
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
+        <icon></icon>JSON
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
+        <icon></icon>Text
+    </a>
+</nav>
+                    <div class="panel m-xs-t-6">
+    <div class="panel-heading">
+        <h4 class="text-sm wt-light text-uppercase text-brand">Page meta</h4>
+    </div>
+
+    <div class="panel-body">
+        <div class="p-xs-b-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Filename:</p>
+            <p class="p-xs-l-2 text-sm">index</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Extension:</p>
+            <p class="p-xs-l-2 text-sm">blade.php</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Path:</p>
+            <p class="p-xs-l-2 text-sm">/about/</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Base URL:</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">URL:</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/about/</p>
+        </div>
+
+        <div class="p-xs-t-4">
+            <p class="text-xs text-dark-soft text-uppercase">Global Variable:</p>
+            <p class="p-xs-l-2 text-sm">some global variable</p>
+        </div>
+    </div>
+</div>
+                                    </div>
+
+                <div class="col-xs-8 demo-page">
+                        <h2>About</h2>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>
+<!DOCTYPE html>

--- a/tests/snapshots/default/source/about/index.blade.php
+++ b/tests/snapshots/default/source/about/index.blade.php
@@ -1,0 +1,5 @@
+@extends('_layouts.master')
+
+@section('body')
+    <h2>About</h2>
+@endsection

--- a/tests/snapshots/default_snapshot/about/index.html
+++ b/tests/snapshots/default_snapshot/about/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
+    </head>
+    <body class="border-t-3 border-primary full-height">
+
+        <nav class="navbar navbar-brand">
+            <div class="container">
+                <div class="navbar-content">
+                    <div>
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
+                            <strong>Jigsaw Collections Demo</strong>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </nav>
+
+        <div class="container m-xs-b-6">
+            <div class="row">
+
+                <div class="col-xs-4">
+                    <nav class="nav-list">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
+        <icon></icon>Posts
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
+        <icon></icon>Pagination
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
+        <icon></icon>Categories
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw.test/people">
+        <icon></icon>People
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
+        <icon></icon>Variables
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
+        <icon></icon>JSON
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
+        <icon></icon>Text
+    </a>
+</nav>
+                    <div class="panel m-xs-t-6">
+    <div class="panel-heading">
+        <h4 class="text-sm wt-light text-uppercase text-brand">Page meta</h4>
+    </div>
+
+    <div class="panel-body">
+        <div class="p-xs-b-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Filename:</p>
+            <p class="p-xs-l-2 text-sm">index</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Extension:</p>
+            <p class="p-xs-l-2 text-sm">blade.php</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Path:</p>
+            <p class="p-xs-l-2 text-sm">/about</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Base URL:</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">URL:</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/about</p>
+        </div>
+
+        <div class="p-xs-t-4">
+            <p class="text-xs text-dark-soft text-uppercase">Global Variable:</p>
+            <p class="p-xs-l-2 text-sm">some global variable</p>
+        </div>
+    </div>
+</div>
+                                    </div>
+
+                <div class="col-xs-8 demo-page">
+                        <h2>About</h2>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>
+<!DOCTYPE html>


### PR DESCRIPTION
Found that `$this->outputPathResolver->link()`  would generate path without a leading slash for index files, e.g. index.blade.php, index.html, index.md, when using pretty urls (which is the default!)

This causes problem when we have `source/blog/index.blade.php` instead of `source/blog.blade.php`. `link()` would return `blog` for the former file, and return `/blog` for the latter file.

For example, GenerateSitemap.php from the blog template would generate the following if having `source/blog/index.blade.php`
```diff
   <url>
-   <loc>https://jigsaw-blog-template.tighten.co/blog</loc>
+   <loc>https://jigsaw-blog-template.tighten.coblog</loc>
    <lastmod>2025-11-27T07:21:16+00:00</lastmod>
    <changefreq>daily</changefreq>
   </url>
```

I have traced back to the commit https://github.com/tighten/jigsaw/commit/7aa603ab2d5177eaf13a2c4e46b6512789d925f4#diff-76e91e6d5ebc8f831ce78c19c83441aa3b719af6a3d4098823f9195a639ec285R11 that introduced the change, and I think it was merely a bug, `ltrim()` should be applied right before `$this->trimPath()`.



