### PR TITLE
Replace deprecated Symfony Console add() with addCommand()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,12 +37,12 @@
         "nunomaduro/collision": "^8.1",
         "ramsey/uuid": "^4.9",
         "spatie/laravel-ignition": "^2.4",
-        "symfony/console": "^6.0 || ^7.0",
-        "symfony/error-handler": "^6.0 || ^7.0",
-        "symfony/finder": "^6.0 || ^7.0",
-        "symfony/process": "^6.0 || ^7.0",
-        "symfony/var-dumper": "^6.0 || ^7.0",
-        "symfony/yaml": "^6.0 || ^7.0",
+        "symfony/console": "^7.4 || ^8.0",
+        "symfony/error-handler": "^7.4 || ^8.0",
+        "symfony/finder": "^7.4 || ^8.0",
+        "symfony/process": "^7.4 || ^8.0",
+        "symfony/var-dumper": "^7.4 || ^8.0",
+        "symfony/yaml": "^7.4 || ^8.0",
         "vlucas/phpdotenv": "^5.6"
     },
     "require-dev": {

--- a/jigsaw
+++ b/jigsaw
@@ -23,9 +23,9 @@ $app->bootstrapWith([
 ]);
 
 $application = new Symfony\Component\Console\Application('Jigsaw', '1.8.3');
-$application->add($app[TightenCo\Jigsaw\Console\InitCommand::class]);
-$application->add(new TightenCo\Jigsaw\Console\BuildCommand($app));
-$application->add(new TightenCo\Jigsaw\Console\ServeCommand($app));
+$application->addCommand($app[TightenCo\Jigsaw\Console\InitCommand::class]);
+$application->addCommand(new TightenCo\Jigsaw\Console\BuildCommand($app));
+$application->addCommand(new TightenCo\Jigsaw\Console\ServeCommand($app));
 $application->setCatchExceptions(false);
 
 TightenCo\Jigsaw\Jigsaw::addUserCommands($application, $app);

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -62,7 +62,7 @@ class Jigsaw
     public static function addUserCommands($app, $container)
     {
         foreach (self::$commands as $command) {
-            $app->add(new $command($container));
+            $app->addCommand(new $command($container));
         }
     }
 


### PR DESCRIPTION
This PR fixes the warning below:

```bash
Since symfony/console 7.4: The "Symfony\Component\Console\Application::add()" method is deprecated and will be removed in Symfony 8.0, use "Symfony\Component\Console\Application::addCommand()" instead.
```