### PR TITLE
Add output markdown option

### DIFF
--- a/src/Providers/CollectionServiceProvider.php
+++ b/src/Providers/CollectionServiceProvider.php
@@ -55,7 +55,7 @@ class CollectionServiceProvider extends ServiceProvider
             return new CollectionItemHandler($app['config'], [
                 $app[MarkdownHandler::class],
                 $app[BladeHandler::class],
-            ]);
+            ], $app[FrontMatterParser::class]);
         });
     }
 


### PR DESCRIPTION
In this AI era, many websites offer a *markdown* version of their pages using the same URL with a `.md` extension (like this: [https://laravel.com/docs/12.x/ai-sdk.md](https://laravel.com/docs/12.x/ai-sdk.md)), for easier LLM consumption.

This PR adds a collection option to Jigsaw to automatically generate these `.md` files.

### Usage

In `config.php`:

```diff
  'collections' => [
      'posts' => [
          'path' => 'blog/{filename}',
+          'output_markdown' => true,
      ],
  ],
```

This produces both `blog/my-post/index.html` (or `blog/my-post.html`) and `blog/my-post.md` for each collection item.

### Implementation

The `CollectionItemHandler` now returns two `OutputFile` instances to the build output when `output_markdown` is enabled: the original file and a raw Markdown version. It uses the existing `FrontMatterParser::extractContent()` method to strip YAML front matter. No new files or dependencies are introduced.
