### PR TITLE
Revert Vite test and caching commits

### DIFF
--- a/src/Support/Vite.php
+++ b/src/Support/Vite.php
@@ -7,8 +7,6 @@ use Illuminate\Support\HtmlString;
 
 class Vite
 {
-    private array $manifests = [];
-
     private function hotFilePath()
     {
         return source_path('hot');
@@ -32,7 +30,12 @@ class Vite
         }
 
         $manifestPath = source_path($assetPath . '/manifest.json');
-        $manifest = $this->manifests[$manifestPath] ??= $this->readManifest($manifestPath);
+
+        if (! file_exists($manifestPath)) {
+            throw new Exception('The Vite manifest does not exist. Please run `npm run build` first or start the dev server.');
+        }
+
+        $manifest = json_decode(file_get_contents($manifestPath), true);
 
         if (! isset($manifest[$asset])) {
             throw new Exception('Main entry point not found in Vite manifest.');
@@ -58,14 +61,5 @@ class Vite
         }
 
         return new HtmlString(sprintf('<script type="module" src="%s"></script>', "{$devServerUrl}/@vite/client"));
-    }
-
-    private function readManifest(string $manifestPath): array
-    {
-        if (! file_exists($manifestPath)) {
-            throw new Exception('The Vite manifest does not exist. Please run `npm run build` first or start the dev server.');
-        }
-
-        return json_decode(file_get_contents($manifestPath), true);
     }
 }

--- a/tests/ViteTest.php
+++ b/tests/ViteTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use Exception;
 use PHPUnit\Framework\Attributes\Test;
 use TightenCo\Jigsaw\Jigsaw;
 use TightenCo\Jigsaw\Support\Vite;
@@ -56,102 +55,5 @@ class ViteTest extends TestCase
         app(Jigsaw::class)->setSourcePath("{$this->tmp}/source");
 
         $this->assertEquals((new Vite)->url($url = 'source/_assets/js/main.js'), 'http://localhost:3000/' . $url);
-    }
-
-    #[Test]
-    public function throws_when_manifest_does_not_exist()
-    {
-        $this->createSource(['source' => []]);
-        app(Jigsaw::class)->setSourcePath("{$this->tmp}/source");
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('The Vite manifest does not exist.');
-
-        (new Vite)->url('source/_assets/js/main.js');
-    }
-
-    #[Test]
-    public function throws_when_asset_is_not_in_manifest()
-    {
-        $manifest = json_encode([
-            'source/_assets/js/main.js' => ['file' => 'assets/app.versioned.js'],
-        ], JSON_UNESCAPED_SLASHES);
-
-        $this->createSource(['source' => [
-            'assets' => ['build' => ['manifest.json' => $manifest]],
-        ]]);
-
-        app(Jigsaw::class)->setSourcePath("{$this->tmp}/source");
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Main entry point not found in Vite manifest.');
-
-        (new Vite)->url('source/_assets/js/missing.js');
-    }
-
-    #[Test]
-    public function returns_build_asset_url_with_custom_asset_path()
-    {
-        $manifest = json_encode([
-            'source/_assets/js/main.js' => ['file' => 'assets/app.versioned.js'],
-        ], JSON_UNESCAPED_SLASHES);
-
-        $this->createSource(['source' => [
-            'custom' => ['dist' => ['manifest.json' => $manifest]],
-        ]]);
-
-        app(Jigsaw::class)->setSourcePath("{$this->tmp}/source");
-
-        $this->assertEquals(
-            '/custom/dist/assets/app.versioned.js',
-            (new Vite)->url('source/_assets/js/main.js', '/custom/dist'),
-        );
-    }
-
-    #[Test]
-    public function returns_consistent_results_across_multiple_calls_on_same_instance()
-    {
-        $manifest = json_encode([
-            'source/_assets/js/main.js' => ['file' => 'assets/app.versioned.js'],
-            'source/_assets/css/main.css' => ['file' => 'assets/app.versioned.css'],
-        ], JSON_UNESCAPED_SLASHES);
-
-        $this->createSource(['source' => [
-            'assets' => ['build' => ['manifest.json' => $manifest]],
-        ]]);
-
-        app(Jigsaw::class)->setSourcePath("{$this->tmp}/source");
-
-        $vite = new Vite;
-
-        $this->assertSame($vite->url('source/_assets/js/main.js'), $vite->url('source/_assets/js/main.js'));
-        $this->assertSame($vite->url('source/_assets/css/main.css'), $vite->url('source/_assets/css/main.css'));
-    }
-
-    #[Test]
-    public function new_instance_reads_fresh_manifest_after_update()
-    {
-        $manifest = json_encode([
-            'source/_assets/js/main.js' => ['file' => 'assets/app-v1.js'],
-        ], JSON_UNESCAPED_SLASHES);
-
-        $this->createSource(['source' => [
-            'assets' => ['build' => ['manifest.json' => $manifest]],
-        ]]);
-
-        app(Jigsaw::class)->setSourcePath("{$this->tmp}/source");
-
-        $firstUrl = (new Vite)->url('source/_assets/js/main.js');
-        $this->assertStringContainsString('app-v1.js', $firstUrl);
-
-        // Simulate a rebuild updating the manifest on disk
-        $updatedManifest = json_encode([
-            'source/_assets/js/main.js' => ['file' => 'assets/app-v2.js'],
-        ], JSON_UNESCAPED_SLASHES);
-        file_put_contents("{$this->tmp}/source/assets/build/manifest.json", $updatedManifest);
-
-        // A new instance must read the updated file, not return stale cached data
-        $secondUrl = (new Vite)->url('source/_assets/js/main.js');
-        $this->assertStringContainsString('app-v2.js', $secondUrl);
     }
 }


### PR DESCRIPTION
Reverts two commits that were accidentally pushed directly to `main`:

- `4562d20` cache manifest per instance instead of static to prevent stale reads
- `602d771` add missing Vite tests including static cache regression

These changes should be proposed through a proper PR instead.