### PR TITLE
Allow dynamic collection pagination

### DIFF
--- a/src/Collection/CollectionPaginator.php
+++ b/src/Collection/CollectionPaginator.php
@@ -15,27 +15,27 @@ class CollectionPaginator
         $this->outputPathResolver = $outputPathResolver;
     }
 
-    public function paginate($file, $items, $perPage, $prefix)
+    public function paginate(string $relativePath, string $filename, $items, $perPage, string $prefix = '')
     {
         $chunked = collect($items)->chunk($perPage);
         $totalPages = $chunked->count();
         $this->prefix = $prefix;
-        $numberedPageLinks = $chunked->map(function ($_, $i) use ($file) {
+        $numberedPageLinks = $chunked->map(function ($_, $i) use ($relativePath, $filename) {
             $page = $i + 1;
 
-            return ['number' => $page, 'path' => $this->getPageLink($file, $page)];
+            return ['number' => $page, 'path' => $this->getPageLink($relativePath, $filename, $page)];
         })->pluck('path', 'number');
 
-        return $chunked->map(function ($items, $i) use ($file, $totalPages, $numberedPageLinks) {
+        return $chunked->map(function ($items, $i) use ($relativePath, $filename, $totalPages, $numberedPageLinks) {
             $currentPage = $i + 1;
 
             return new IterableObject([
                 'items' => $items,
-                'previous' => $currentPage > 1 ? $this->getPageLink($file, $currentPage - 1) : null,
-                'current' => $this->getPageLink($file, $currentPage),
-                'next' => $currentPage < $totalPages ? $this->getPageLink($file, $currentPage + 1) : null,
-                'first' => $this->getPageLink($file, 1),
-                'last' => $this->getPageLink($file, $totalPages),
+                'previous' => $currentPage > 1 ? $this->getPageLink($relativePath, $filename, $currentPage - 1) : null,
+                'current' => $this->getPageLink($relativePath, $filename, $currentPage),
+                'next' => $currentPage < $totalPages ? $this->getPageLink($relativePath, $filename, $currentPage + 1) : null,
+                'first' => $this->getPageLink($relativePath, $filename, 1),
+                'last' => $this->getPageLink($relativePath, $filename, $totalPages),
                 'currentPage' => $currentPage,
                 'totalPages' => $totalPages,
                 'pages' => $numberedPageLinks,
@@ -43,11 +43,11 @@ class CollectionPaginator
         });
     }
 
-    private function getPageLink($file, $pageNumber)
+    private function getPageLink(string $relativePath, string $filename, int $pageNumber): string
     {
         $link = $this->outputPathResolver->link(
-            $file->getRelativePath(),
-            $file->getFilenameWithoutExtension(),
+            $relativePath,
+            $filename,
             'html',
             $pageNumber,
             $this->prefix,

--- a/src/File/OutputFile.php
+++ b/src/File/OutputFile.php
@@ -22,9 +22,11 @@ class OutputFile
 
     private $prefix;
 
-    public function __construct(InputFile $inputFile, $path, $name, $extension, $contents, $data, $page = 1, $prefix = '')
+    public function __construct(?InputFile $inputFile, $path, $name, $extension, $contents, $data, $page = 1, $prefix = '')
     {
-        $this->setInputFile($inputFile, $data);
+        if ($inputFile !== null) {
+            $this->setInputFile($inputFile, $data);
+        }
         $this->path = $path;
         $this->name = $name;
         $this->extension = $extension;

--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -3,7 +3,9 @@
 namespace TightenCo\Jigsaw\Handlers;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use TightenCo\Jigsaw\Collection\CollectionPaginator;
+use TightenCo\Jigsaw\File\InputFile;
 use TightenCo\Jigsaw\File\OutputFile;
 use TightenCo\Jigsaw\File\TemporaryFilesystem;
 use TightenCo\Jigsaw\PageData;
@@ -42,35 +44,67 @@ class PaginatedPageHandler
         return isset($content->frontMatter['pagination']);
     }
 
-    public function handle($file, PageData $pageData)
+    public function handle($file, PageData $pageData): Collection
     {
         $page = $pageData->page;
         $page->addVariables($this->getPageVariables($file));
         $collection = $page->pagination->collection;
         $prefix = $page->pagination->prefix
-            ?: $page->collections->{$collection}->prefix
+            ?: $page->collections->{$collection}?->prefix
             ?: $page->prefix
             ?: '';
+        $perPage = $page->pagination->perPage
+            ?: $page->collections->{$collection}?->perPage
+            ?: $page->perPage
+            ?: 10;
+        $extension = strtolower($file->getExtension());
+        $outputExtension = ($extension == 'php' || $extension == 'md') ? 'html' : $extension;
 
-        return $this->paginator->paginate(
-            $file,
+        return $this->buildOutputFiles(
+            $file->getRelativePath(),
+            $file->getFilenameWithoutExtension(),
+            $outputExtension,
             $pageData->get($collection),
-            $page->pagination->perPage
-                ?: $page->collections->{$collection}->perPage
-                ?: $page->perPage
-                ?: 10,
+            $perPage,
             $prefix,
-        )->map(function ($page) use ($file, $pageData, $prefix) {
+            $pageData,
+            fn ($pageData) => $this->renderFile($file, $pageData),
+            $file,
+        );
+    }
+
+    public function handleDefinition(string $relativePath, string $filename, string $template, $items, int $perPage, PageData $pageData): Collection
+    {
+        return $this->buildOutputFiles(
+            $relativePath,
+            $filename,
+            'html',
+            $items,
+            $perPage,
+            '',
+            $pageData,
+            fn ($pageData) => $this->view->renderView($template, $pageData),
+        );
+    }
+
+    private function buildOutputFiles(string $relativePath, string $filename, string $extension, $items, int $perPage, string $prefix, PageData $pageData, callable $renderer, ?InputFile $inputFile = null): Collection
+    {
+        return $this->paginator->paginate(
+            $relativePath,
+            $filename,
+            $items,
+            $perPage,
+            $prefix,
+        )->map(function ($page) use ($relativePath, $filename, $extension, $pageData, $prefix, $renderer, $inputFile) {
             $pageData->setPagePath($page->current);
             $pageData->put('pagination', $page);
-            $extension = strtolower($file->getExtension());
 
             return new OutputFile(
-                $file,
-                $file->getRelativePath(),
-                $file->getFilenameWithoutExtension(),
-                ($extension == 'php' || $extension == 'md') ? 'html' : $extension,
-                $this->render($file, $pageData),
+                $inputFile,
+                $relativePath,
+                $filename,
+                $extension,
+                $renderer($pageData),
                 $pageData,
                 $page->currentPage,
                 $prefix,
@@ -83,7 +117,7 @@ class PaginatedPageHandler
         return $this->parser->getFrontMatter($file->getContents());
     }
 
-    private function render($file, $pageData)
+    private function renderFile($file, $pageData)
     {
         $bladeContent = $this->parser->getBladeContent($file->getContents());
         $bladeFilePath = $this->temporaryFilesystem->put(

--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -2,8 +2,8 @@
 
 namespace TightenCo\Jigsaw\Handlers;
 
-use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use TightenCo\Jigsaw\Collection\CollectionPaginator;
 use TightenCo\Jigsaw\File\InputFile;
 use TightenCo\Jigsaw\File\OutputFile;

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -28,6 +28,8 @@ class Jigsaw
 
     protected $verbose;
 
+    protected $pendingPages = [];
+
     protected static $commands = [];
 
     public function __construct(
@@ -64,6 +66,15 @@ class Jigsaw
         $app->addCommands(array_map(fn ($command) => new $command($container), self::$commands));
     }
 
+    public function paginateCollection(string $path, string $collection, string $template, int $perPage = 10, array $variables = []): self
+    {
+        $this->setConfig("collections.{$collection}", []);
+
+        $this->pendingPages[] = compact('path', 'collection', 'template', 'perPage', 'variables');
+
+        return $this;
+    }
+
     protected function buildCollections()
     {
         $this->remoteItemLoader->write($this->siteData->collections, $this->getSourcePath());
@@ -81,6 +92,7 @@ class Jigsaw
                 $this->getSourcePath(),
                 $this->getDestinationPath(),
                 $this->siteData,
+                $this->pendingPages,
             );
         $this->outputPaths = $this->pageInfo->keys();
 

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -6,6 +6,7 @@ use Illuminate\Container\Container;
 use TightenCo\Jigsaw\Console\ConsoleOutput;
 use TightenCo\Jigsaw\File\Filesystem;
 use TightenCo\Jigsaw\File\InputFile;
+use TightenCo\Jigsaw\Handlers\PaginatedPageHandler;
 
 class SiteBuilder
 {
@@ -42,10 +43,11 @@ class SiteBuilder
         return $this;
     }
 
-    public function build($source, $destination, $siteData)
+    public function build($source, $destination, $siteData, $pendingPages = [])
     {
         $this->prepareDirectory($this->cachePath, ! $this->useCache);
-        $generatedFiles = $this->generateFiles($source, $siteData);
+        $generatedFiles = $this->generateFiles($source, $siteData)
+            ->merge($this->generatePaginatedPages($pendingPages, $siteData));
         $this->prepareDirectory($destination, true);
         $outputFiles = $this->writeFiles($generatedFiles, $destination);
         $this->cleanup();
@@ -99,6 +101,34 @@ class SiteBuilder
         return $files;
     }
 
+    private function generatePaginatedPages($pendingPages, $siteData)
+    {
+        if (empty($pendingPages)) {
+            return collect();
+        }
+
+        $handler = collect($this->handlers)->first(fn ($h) => $h instanceof PaginatedPageHandler);
+
+        return collect($pendingPages)->flatMap(function ($def) use ($handler, $siteData) {
+            $relativePath = ltrim(dirname($def['path']), '.');
+            $filename = basename($def['path']);
+            $meta = $this->getMetaDataForPath($relativePath, $filename, $siteData->page->baseUrl);
+
+            $pageData = PageData::withPageMetaData($siteData, $meta);
+            Container::getInstance()->instance('pageData', $pageData);
+            $pageData->page->addVariables($def['variables']);
+
+            return $handler->handleDefinition(
+                $relativePath,
+                $filename,
+                $def['template'],
+                $siteData->get($def['collection']),
+                $def['perPage'],
+                $pageData,
+            );
+        });
+    }
+
     private function writeFiles($files, $destination)
     {
         $this->consoleOutput->writeWritingFiles();
@@ -106,7 +136,7 @@ class SiteBuilder
         return $files->mapWithKeys(function ($file) use ($destination) {
             $outputLink = $this->writeFile($file, $destination);
 
-            return [$outputLink => $file->inputFile()->getPageData()];
+            return [$outputLink => $file->inputFile()?->getPageData()];
         });
     }
 
@@ -134,6 +164,16 @@ class SiteBuilder
         return collect($this->handlers)->first(function ($handler) use ($file) {
             return $handler->shouldHandle($file);
         });
+    }
+
+    private function getMetaDataForPath(string $relativePath, string $filename, ?string $baseUrl): array
+    {
+        $path = rightTrimPath($this->outputPathResolver->link($relativePath, $filename, 'html'));
+        $url = rightTrimPath($baseUrl ?? '') . '/' . trimPath($path);
+        $extension = 'html';
+        $modifiedTime = time();
+
+        return compact('filename', 'baseUrl', 'path', 'relativePath', 'extension', 'url', 'modifiedTime');
     }
 
     private function getMetaData($file, $baseUrl)

--- a/src/View/ViewRenderer.php
+++ b/src/View/ViewRenderer.php
@@ -25,6 +25,11 @@ class ViewRenderer
         return app('view')->file($path, $data->all())->render();
     }
 
+    public function renderView(string $view, $data): string
+    {
+        return app('view')->make($view, $data->all())->render();
+    }
+
     public function renderString($string)
     {
         return app('blade.compiler')->compileString($string);

--- a/tests/DynamicCollectionPaginationTest.php
+++ b/tests/DynamicCollectionPaginationTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use TightenCo\Jigsaw\Jigsaw;
+
+class DynamicCollectionPaginationTest extends TestCase
+{
+    #[Test]
+    public function can_paginate_a_dynamically_registered_collection()
+    {
+        $files = $this->setupSource([
+            '_layouts' => [
+                'tag.blade.php' => '@foreach($pagination->items as $post){{ $post->getFilename() }}@endforeach',
+            ],
+            '_posts' => [
+                'post1.blade.php' => "---\ntags:\n  - php\n---\n",
+                'post2.blade.php' => "---\ntags:\n  - php\n---\n",
+                'post3.blade.php' => "---\ntags:\n  - php\n---\n",
+                'post4.blade.php' => "---\ntags:\n  - laravel\n---\n",
+                'post5.blade.php' => "---\ntags:\n  - laravel\n---\n",
+            ],
+        ]);
+
+        $this->app['events']->afterCollections(function (Jigsaw $jigsaw) {
+            $posts = $jigsaw->getCollection('posts');
+
+            $jigsaw->setConfig('tag_php', $posts->filter(fn ($post) => in_array('php', $post->tags ?? [])));
+            $jigsaw->paginateCollection(
+                path: 'tags/php',
+                collection: 'tag_php',
+                template: '_layouts.tag',
+                perPage: 2,
+            );
+
+            $jigsaw->setConfig('tag_laravel', $posts->filter(fn ($post) => in_array('laravel', $post->tags ?? [])));
+            $jigsaw->paginateCollection(
+                path: 'tags/laravel',
+                collection: 'tag_laravel',
+                template: '_layouts.tag',
+                perPage: 2,
+            );
+        });
+
+        $this->buildSite($files, ['collections' => ['posts' => []]], $pretty = true);
+
+        $phpPage1 = $this->clean($files->getChild('build/tags/php/index.html')->getContent());
+        $phpPage2 = $this->clean($files->getChild('build/tags/php/2/index.html')->getContent());
+        $laravelPage1 = $this->clean($files->getChild('build/tags/laravel/index.html')->getContent());
+
+        $this->assertStringContainsString('post', $phpPage1);
+        $this->assertStringContainsString('post', $phpPage2);
+        $this->assertStringContainsString('post', $laravelPage1);
+        $this->assertFileMissing($this->tmpPath('build/tags/php/3/index.html'));
+        $this->assertFileMissing($this->tmpPath('build/tags/laravel/2/index.html'));
+    }
+
+    #[Test]
+    public function paginate_collection_generates_correct_page_count()
+    {
+        $files = $this->setupSource([
+            '_layouts' => [
+                'items.blade.php' => '{{ $pagination->totalPages }}',
+            ],
+            '_items' => [
+                'item1.blade.php' => '',
+                'item2.blade.php' => '',
+                'item3.blade.php' => '',
+                'item4.blade.php' => '',
+                'item5.blade.php' => '',
+            ],
+        ]);
+
+        $this->app['events']->afterCollections(function (Jigsaw $jigsaw) {
+            $jigsaw->paginateCollection(
+                path: 'list',
+                collection: 'items',
+                template: '_layouts.items',
+                perPage: 2,
+            );
+        });
+
+        $this->buildSite($files, ['collections' => ['items' => []]], $pretty = true);
+
+        $this->assertEquals('3', $this->clean($files->getChild('build/list/index.html')->getContent()));
+        $this->assertEquals('3', $this->clean($files->getChild('build/list/2/index.html')->getContent()));
+        $this->assertEquals('3', $this->clean($files->getChild('build/list/3/index.html')->getContent()));
+        $this->assertFileMissing($this->tmpPath('build/list/4/index.html'));
+    }
+
+    #[Test]
+    public function paginate_collection_exposes_pagination_navigation_links()
+    {
+        $files = $this->setupSource([
+            '_layouts' => [
+                'items.blade.php' => '{{ $pagination->previous }}|{{ $pagination->next }}',
+            ],
+            '_items' => [
+                'item1.blade.php' => '',
+                'item2.blade.php' => '',
+                'item3.blade.php' => '',
+            ],
+        ]);
+
+        $this->app['events']->afterCollections(function (Jigsaw $jigsaw) {
+            $jigsaw->paginateCollection(
+                path: 'list',
+                collection: 'items',
+                template: '_layouts.items',
+                perPage: 1,
+            );
+        });
+
+        $this->buildSite($files, ['collections' => ['items' => []]], $pretty = true);
+
+        $this->assertEquals('|/list/2', $this->clean($files->getChild('build/list/index.html')->getContent()));
+        $this->assertEquals('/list|/list/3', $this->clean($files->getChild('build/list/2/index.html')->getContent()));
+        $this->assertEquals('/list/2|', $this->clean($files->getChild('build/list/3/index.html')->getContent()));
+    }
+
+    #[Test]
+    public function paginate_collection_passes_extra_variables_to_template()
+    {
+        $files = $this->setupSource([
+            '_layouts' => [
+                'items.blade.php' => '{{ $page->label }}',
+            ],
+            '_items' => [
+                'item1.blade.php' => '',
+            ],
+        ]);
+
+        $this->app['events']->afterCollections(function (Jigsaw $jigsaw) {
+            $jigsaw->paginateCollection(
+                path: 'list',
+                collection: 'items',
+                template: '_layouts.items',
+                perPage: 10,
+                variables: ['label' => 'Hello from variables'],
+            );
+        });
+
+        $this->buildSite($files, ['collections' => ['items' => []]], $pretty = true);
+
+        $this->assertEquals('Hello from variables', $this->clean($files->getChild('build/list/index.html')->getContent()));
+    }
+
+    #[Test]
+    public function paginate_collection_can_be_called_multiple_times_for_multiple_collections()
+    {
+        $files = $this->setupSource([
+            '_layouts' => [
+                'items.blade.php' => '{{ $pagination->totalPages }}',
+            ],
+            '_items' => [
+                'item1.blade.php' => '',
+                'item2.blade.php' => '',
+                'item3.blade.php' => '',
+            ],
+        ]);
+
+        $this->app['events']->afterCollections(function (Jigsaw $jigsaw) {
+            $jigsaw->paginateCollection(
+                path: 'list-a',
+                collection: 'items',
+                template: '_layouts.items',
+                perPage: 1,
+            );
+            $jigsaw->paginateCollection(
+                path: 'list-b',
+                collection: 'items',
+                template: '_layouts.items',
+                perPage: 2,
+            );
+        });
+
+        $this->buildSite($files, ['collections' => ['items' => []]], $pretty = true);
+
+        $this->assertEquals('3', $this->clean($files->getChild('build/list-a/index.html')->getContent()));
+        $this->assertEquals('3', $this->clean($files->getChild('build/list-a/3/index.html')->getContent()));
+        $this->assertFileMissing($this->tmpPath('build/list-a/4/index.html'));
+
+        $this->assertEquals('2', $this->clean($files->getChild('build/list-b/index.html')->getContent()));
+        $this->assertEquals('2', $this->clean($files->getChild('build/list-b/2/index.html')->getContent()));
+        $this->assertFileMissing($this->tmpPath('build/list-b/3/index.html'));
+    }
+}

--- a/tests/DynamicCollectionPaginationTest.php
+++ b/tests/DynamicCollectionPaginationTest.php
@@ -49,9 +49,11 @@ class DynamicCollectionPaginationTest extends TestCase
         $phpPage2 = $this->clean($files->getChild('build/tags/php/2/index.html')->getContent());
         $laravelPage1 = $this->clean($files->getChild('build/tags/laravel/index.html')->getContent());
 
-        $this->assertStringContainsString('post', $phpPage1);
-        $this->assertStringContainsString('post', $phpPage2);
-        $this->assertStringContainsString('post', $laravelPage1);
+        $this->assertStringContainsString('post1', $phpPage1);
+        $this->assertStringNotContainsString('post1', $laravelPage1);
+        $this->assertStringContainsString('post4', $laravelPage1);
+        $this->assertStringNotContainsString('post4', $phpPage1);
+        $this->assertStringNotContainsString('post4', $phpPage2);
         $this->assertFileMissing($this->tmpPath('build/tags/php/3/index.html'));
         $this->assertFileMissing($this->tmpPath('build/tags/laravel/2/index.html'));
     }


### PR DESCRIPTION
This PR allows paginating custom, dynamic collections. Fixes #273, although it does not use the config approach suggested there.

### Issue

To paginate a collection, Jigsaw [requires a source Blade template with a pagination key in its YAML](https://jigsaw.tighten.co/docs/collections-pagination/) front matter pointing at the target collection.

This breaks for dynamic collections, those generated at build time, like posts grouped by tag. You can build them in `afterCollections`, but each still needs a source file (`source/tags/php.blade.php`, `source/tags/laravel.blade.php`, `source/tags/javascript.blade.php`, etc.) created before you even know which tags exist.

### Solution

With this PR, you can register paginated collections on the fly thanks to `paginateCollection`. The typical use case is tag/category pages. Let's say you want paginated pages of all your posts with certain tag ("PHP", "JavaScript", etc). In `bootstrap.php`:

```php
$events->afterCollections(function (Jigsaw $jigsaw) {
    $posts = $jigsaw->getCollection('posts');

    $posts->flatMap(fn ($post) => $post->tags ?? [])
        ->unique()
        ->each(function ($tag) use ($jigsaw, $posts) {
            $slug = str($tag)->slug();
            
            $jigsaw->setConfig("tag_{$slug}", $posts->filter(fn ($p) => in_array($tag, $p->tags ?? [])));
            
            
            $jigsaw->paginateCollection(
                path: "tags/{$slug}",
                collection: "tag_{$slug}",
                template: '_layouts.tag',
                perPage: 5,
                variables: ['tag' => $tag],
            );
        });
});
```

That generates `build/tags/php/index.html`, `build/tags/php/2/index.html`, etc. Same pagination object (`$pagination->items`, `$pagination->next`, etc.) as the file-based approach, just driven from code instead of a source file.

## What changed

- **New `Jigsaw::paginateCollection()` API**: registers a paginated page definition (path, collection, template, perPage, optional variables) for deferred rendering after collections are built
- **`PaginatedPageHandler::handleDefinition()`**: new method that renders paginated pages from a template view name instead of a source file
- **`CollectionPaginator::paginate()`**: refactored to accept `relativePath` and `filename` as separate strings instead of a `$file` object, decoupling it from the filesystem
- **`OutputFile`**: `InputFile` is now nullable to support pages that have no backing source file
- **`SiteBuilder::generatePaginatedPages()`**: new private method that processes pending page definitions and merges them into the build output
- **`ViewRenderer::renderView()`**: new method to render a view by name (using `view()->make()`) rather than by file path

## How to test

1. In `bootstrap.php`, hook into `afterCollections`. Use teh snippet presented above.
2. Create a `_layouts/tag.blade.php` that uses `$pagination`.
3. Run `./vendor/bin/jigsaw build` and verify `build/tags/php/index.html` and paginated sub-pages are generated correctly.
4. Run `./vendor/bin/phpunit tests/DynamicCollectionPaginationTest.php`, all 5 tests should pass.