### PR TITLE
Add viewPath meta field for nested collection items

### DIFF
--- a/src/Loaders/CollectionDataLoader.php
+++ b/src/Loaders/CollectionDataLoader.php
@@ -123,13 +123,16 @@ class CollectionDataLoader
         $filename = $file->getFilenameWithoutExtension();
         $baseUrl = $data->baseUrl;
         $relativePath = $file->getRelativePath();
+        $viewPath = $relativePath
+            ? str_replace(['/', '\\'], '.', $relativePath) . '.' . $filename
+            : $filename;
         $extension = $file->getFullExtension();
         $collectionName = $collection->name;
         $collection = $collectionName;
         $source = $file->getPath();
         $modifiedTime = $file->getLastModifiedTime();
 
-        return compact('filename', 'baseUrl', 'relativePath', 'extension', 'collection', 'collectionName', 'source', 'modifiedTime');
+        return compact('filename', 'baseUrl', 'relativePath', 'viewPath', 'extension', 'collection', 'collectionName', 'source', 'modifiedTime');
     }
 
     private function buildUrls($paths)

--- a/tests/CollectionItemTest.php
+++ b/tests/CollectionItemTest.php
@@ -158,6 +158,50 @@ class CollectionItemTest extends TestCase
     }
 
     #[Test]
+    public function collection_item_page_metadata_contains_view_path_for_nested_items()
+    {
+        $config = collect(['collections' => ['collection' => []]]);
+        $files = $this->setupSource([
+            '_layouts' => [
+                'item.blade.php' => '@section(\'content\') @endsection',
+            ],
+            '_collection' => [
+                'nested' => [
+                    'page.blade.php' => "@extends('_layouts.item')\n" . '{{ $page->getViewPath() }}',
+                ],
+            ],
+        ]);
+
+        $this->buildSite($files, $config, $pretty = true);
+
+        $this->assertEquals(
+            'nested.page',
+            $this->clean($files->getChild('build/collection/page/index.html')->getContent()),
+        );
+    }
+
+    #[Test]
+    public function collection_item_view_path_for_flat_items_equals_filename()
+    {
+        $config = collect(['collections' => ['collection' => []]]);
+        $files = $this->setupSource([
+            '_layouts' => [
+                'item.blade.php' => '@section(\'content\') @endsection',
+            ],
+            '_collection' => [
+                'page.blade.php' => "@extends('_layouts.item')\n" . '{{ $page->getViewPath() }}',
+            ],
+        ]);
+
+        $this->buildSite($files, $config, $pretty = true);
+
+        $this->assertEquals(
+            'page',
+            $this->clean($files->getChild('build/collection/page/index.html')->getContent()),
+        );
+    }
+
+    #[Test]
     public function collection_item_page_metadata_contains_extension()
     {
         $config = collect(['collections' => ['collection' => []]]);


### PR DESCRIPTION
Closes #756.

## Issue

If you have collection items in nested source directories (e.g., `_posts/2024/foo.md`) and need a way to get the flat contents of that file, there is no built-in function to return the path and filename in Blade format (`2024.foo`).

This breaks [the default RSS feed](https://github.com/tighten/jigsaw-blog-template/blob/main/source/_components/post-as-rss-item.blade.php#L12), which uses `$entry->getFilename()`, because that returns `foo` instead of `2024.foo`.

This is not a bug, but adding a small function to get the view path is useful for users of nested source directories.

## Solution

This PR adds a `viewPath` field to the collection item `_meta`, joining `relativePath` and `filename` with dots. `PageVariable::__call` already exposes `_meta` keys as `get*()` methods, so templates can use:

```blade
@include('_posts.' . $entry->getViewPath())
```

This returns `2024.foo` for nested items and `foo` for flat ones.