### PR TITLE
Fix collection items colliding when they share a basename

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -5,6 +5,7 @@ namespace TightenCo\Jigsaw\Collection;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Str;
 use TightenCo\Jigsaw\IterableObject;
 
 class Collection extends BaseCollection
@@ -29,10 +30,17 @@ class Collection extends BaseCollection
             ->map($this->getMap())
             ->filter($this->getFilter())
             ->keyBy(function ($item) {
-                return $item->getFilename();
+                return self::itemKey($item->getRelativePath(), $item->getFilename());
             });
 
         return $this->updateItems($this->addAdjacentItems($sortedItems));
+    }
+
+    public static function itemKey($relativePath, $filename)
+    {
+        return $relativePath && ! Str::startsWith($relativePath, '_')
+            ? $relativePath . '/' . $filename
+            : $filename;
     }
 
     public function updateItems(BaseCollection $items)
@@ -46,7 +54,7 @@ class Collection extends BaseCollection
     {
         $count = $items->count();
         $adjacentItems = $items->map(function ($item) {
-            return $item->getFilename();
+            return self::itemKey($item->getRelativePath(), $item->getFilename());
         });
         $previousItems = $adjacentItems->prepend(null)->take($count);
         $nextItems = $adjacentItems->push(null)->take(-$count);

--- a/src/File/InputFile.php
+++ b/src/File/InputFile.php
@@ -42,6 +42,13 @@ class InputFile
         return count($parts) == 1 ? '' : $parts[0];
     }
 
+    public function getRelativePathBelowTopLevel()
+    {
+        $relativePath = str_replace('\\', '/', $this->file->getRelativePath());
+
+        return ltrim((string) Str::after($relativePath, $this->topLevelDirectory()), '/');
+    }
+
     public function getFilenameWithoutExtension()
     {
         return $this->getBasename('.' . $this->getFullExtension());

--- a/src/Handlers/CollectionItemHandler.php
+++ b/src/Handlers/CollectionItemHandler.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use TightenCo\Jigsaw\Builders\PlainMarkdownBuilder;
+use TightenCo\Jigsaw\Collection\Collection as JigsawCollection;
 use TightenCo\Jigsaw\File\OutputFile;
 use TightenCo\Jigsaw\Parsers\FrontMatterParser;
 
@@ -56,7 +57,10 @@ class CollectionItemHandler
             return $handler->shouldHandle($file);
         });
         $collectionName = $this->getCollectionName($file);
-        $pageData->setPageVariableToCollectionItem($collectionName, $file->getFilenameWithoutExtension());
+        $pageData->setPageVariableToCollectionItem(
+            $collectionName,
+            JigsawCollection::itemKey($file->getRelativePathBelowTopLevel(), $file->getFilenameWithoutExtension()),
+        );
 
         if ($pageData->page === null) {
             return null;

--- a/tests/CollectionItemTest.php
+++ b/tests/CollectionItemTest.php
@@ -202,6 +202,32 @@ class CollectionItemTest extends TestCase
     }
 
     #[Test]
+    public function collection_items_with_same_basename_in_different_directories_do_not_collide()
+    {
+        $config = collect(['collections' => [
+            'collection' => [
+                'path' => 'collection/{relativePath}/{filename}',
+            ],
+        ]]);
+        $files = $this->setupSource([
+            '_layouts' => [
+                'item.blade.php' => '@section(\'content\') @endsection',
+            ],
+            '_collection' => [
+                'page.blade.php' => "@extends('_layouts.item')\nROOT",
+                'nested' => [
+                    'page.blade.php' => "@extends('_layouts.item')\nNESTED",
+                ],
+            ],
+        ]);
+
+        $this->buildSite($files, $config);
+
+        $this->assertEquals('ROOT', trim($files->getChild('build/collection/page.html')->getContent()));
+        $this->assertEquals('NESTED', trim($files->getChild('build/collection/nested/page.html')->getContent()));
+    }
+
+    #[Test]
     public function collection_item_page_metadata_contains_extension()
     {
         $config = collect(['collections' => ['collection' => []]]);


### PR DESCRIPTION
Closes #674 

## Issue

Two files in the same collection with the same basename (e.g. `_posts/example.md` and `_posts/foo/example.md`) would silently collapse into a single output. The collection is keyed by `getFilename()`, so the second item overwrites the first.

## Solution

Items are now keyed by `relativePath/filename` when nested. the new method `itemKey` encapsulates the logic. User-facing access by basename (`$siteData->posts->{name}`) is unchanged for flat collections. For nested collections, two items that previously masked each other are now both reachable.