### PR TITLE
Add --router option to jigsaw serve

### DIFF
--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -47,6 +47,12 @@ class ServeCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Skip build before serving?',
+            )
+            ->addOption(
+                'router',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Path to a custom PHP router script.',
             );
     }
 
@@ -68,7 +74,13 @@ class ServeCommand extends Command
 
         $this->console->info("Server started on http://{$host}:{$port}");
 
-        passthru("php -S {$host}:{$port} -t " . escapeshellarg($this->getBuildPath($env)));
+        $command = "php -S {$host}:{$port} -t " . escapeshellarg($this->getBuildPath($env));
+
+        if ($router = $this->input->getOption('router')) {
+            $command .= ' ' . escapeshellarg($router);
+        }
+
+        passthru($command);
     }
 
     private function getBuildPath($env)


### PR DESCRIPTION
Closes #750 

## Issue

`jigsaw serve` uses PHP’s built-in server. As noted in the issue, when the directory contains a dot, it incorrectly interprets such paths as file requests. This can be bypassed by adding a `--router` parameter to the `php -S` command, but Jigsaw does not support it.

Note: the issue was fixed in PHP 8.4 ([check notes here](https://www.php.net/manual/en/migration84.other-changes.php#migration84.other-changes.sapi.cli)) - but I think it's worth addressing given Jigsaw also supports 8.2 and 8.3

## Solution

This PR adds support for an optional `--router` flag. If present, it is passed to the `php -S` invocation.
