### PR TITLE
Fix console output styling that broke in Symfony 8

### DIFF
--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -59,7 +59,7 @@ class ConsoleOutput extends SymfonyConsoleOutput
         $progressBar = $this->progressBar($name);
 
         if ($progressBar->getMessage()) {
-            $this->sections['message']->overwrite($progressBar->getMessage());
+            $this->overwriteSection($this->sections['message'], $progressBar->getMessage());
         }
 
         $progressBar->addSteps($steps)->start();
@@ -77,7 +77,8 @@ class ConsoleOutput extends SymfonyConsoleOutput
             $cacheMessage = '';
         }
 
-        $this->sections['intro']->overwrite(
+        $this->overwriteSection(
+            $this->sections['intro'],
             '<fg=green>Building '
             . $env
             . ' site '
@@ -91,7 +92,7 @@ class ConsoleOutput extends SymfonyConsoleOutput
     public function writeWritingFiles()
     {
         $this->sections['progress']->clear();
-        $this->sections['message']->overwrite('<fg=yellow>Writing files to destination...</>');
+        $this->overwriteSection($this->sections['message'], '<fg=yellow>Writing files to destination...</>');
 
         return $this;
     }
@@ -108,7 +109,8 @@ class ConsoleOutput extends SymfonyConsoleOutput
             $cacheMessage = '';
         }
 
-        $this->sections['intro']->overwrite(
+        $this->overwriteSection(
+            $this->sections['intro'],
             '<fg=yellow>Build time: </><fg=white>' .
             $time .
             ' seconds</> ' .
@@ -120,8 +122,13 @@ class ConsoleOutput extends SymfonyConsoleOutput
 
     public function writeConclusion()
     {
-        $this->sections['message']->overwrite('<fg=green>Site built successfully!</>');
+        $this->overwriteSection($this->sections['message'], '<fg=green>Site built successfully!</>');
 
         return $this;
+    }
+
+    protected function overwriteSection($section, string $message): void
+    {
+        $section->overwrite($this->getFormatter()->format($message));
     }
 }

--- a/tests/ConsoleOutputTest.php
+++ b/tests/ConsoleOutputTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests;
+
+use Composer\InstalledVersions;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use ReflectionProperty;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+use TightenCo\Jigsaw\Console\ConsoleOutput;
+
+class ConsoleOutputTest extends PHPUnitTestCase
+{
+    #[Test]
+    public function second_section_overwrite_does_not_emit_raw_style_tags(): void
+    {
+        if (version_compare($this->symfonyConsoleVersion(), '8.0.0', '<')) {
+            $this->markTestSkipped('Regression only applies to Symfony Console 8+.');
+        }
+
+        $output = $this->captureConsoleOutput();
+
+        $output->setup(OutputInterface::VERBOSITY_NORMAL);
+        $output->writeIntro('local');
+        $output->writeTime('13.1');
+        $output->writeWritingFiles();
+        $output->writeConclusion();
+
+        $content = $this->readStream($output);
+
+        $this->assertStringContainsString('Build time:', $content);
+        $this->assertStringContainsString('Site built successfully!', $content);
+        $this->assertStringNotContainsString('<fg=', $content);
+        $this->assertStringNotContainsString('</>', $content);
+    }
+
+    private function captureConsoleOutput(): ConsoleOutput
+    {
+        $stream = fopen('php://memory', 'w+');
+        $output = new ConsoleOutput;
+        $output->setDecorated(true);
+
+        $streamProperty = new ReflectionProperty(StreamOutput::class, 'stream');
+        $streamProperty->setAccessible(true);
+        $streamProperty->setValue($output, $stream);
+
+        return $output;
+    }
+
+    private function readStream(ConsoleOutput $output): string
+    {
+        $streamProperty = new ReflectionProperty(StreamOutput::class, 'stream');
+        $streamProperty->setAccessible(true);
+        $stream = $streamProperty->getValue($output);
+
+        rewind($stream);
+
+        return stream_get_contents($stream);
+    }
+
+    private function symfonyConsoleVersion(): string
+    {
+        return InstalledVersions::getVersion('symfony/console');
+    }
+}


### PR DESCRIPTION
A change in Symfony 8, which we added support for in v1.8.6, caused styling tags to be output literally to the console.

- In Symfony Console 7, `overwrite()` always clears the section and calls `writeln()`, which runs text through the formatter.
- In Symfony Console 8, when the section already has content and output is decorated, `overwrite()` follows a different path: it stores the raw string in the section buffer and writes it with `parent::doWrite()` without going through `Output::write()`, bypassing the formatter.

To solve this, this PR preformats text sections before sending them to `overwrite()`.

